### PR TITLE
Show import upload date rather than PK

### DIFF
--- a/opentreemap/importer/templates/importer/partials/import_table.html
+++ b/opentreemap/importer/templates/importer/partials/import_table.html
@@ -2,7 +2,7 @@
 <table class="table table-hover">
     <thead>
         <tr>
-            <th>{% trans "Import Event" %}</th>
+            <th>{% trans "Uploaded Date" %}</th>
             <th>{% trans "Status" %}</th>
             <th>{% trans "Rows" %}</th>
             <th>{% trans "View" %}</th>
@@ -11,7 +11,7 @@
     <tbody>
     {% for ie in things %}
         <tr>
-            <td>{{ ie }}</td>
+            <td>{{ ie.created }}</td>
             <td>{{ ie.status_summary }}</td>
             <td>
                 {% if ie.is_finished %}
@@ -29,4 +29,3 @@
     {% endfor %}
     </tbody>
 </table>
-


### PR DESCRIPTION
The import event id is an internal primary key shared across all instances. It is confusing for the first import created by the map owner to be labeled 17, and the next labeled 21.

The upload date is not only less confusing, but provides additional, useful information.

Fixes #1891 

![screen shot 2015-01-13 at 12 11 52 pm](https://cloud.githubusercontent.com/assets/17363/5727735/78c2e202-9b22-11e4-8ab6-4138a5752d69.png)
