### PR TITLE
Fix "Tree Present" handling

### DIFF
--- a/opentreemap/importer/models/trees.py
+++ b/opentreemap/importer/models/trees.py
@@ -134,19 +134,22 @@ class TreeImportRow(GenericImportRow):
         else:
             plot = Plot(instance=self.import_event.instance)
 
-        # Even if TREE_PRESENT is False, a tree can be spawned if there
-        # is tree data later
-        tree = plot.current_tree()
+        self._commit_plot_data(data, plot)
 
-        # Check for an existing tree:
+        # TREE_PRESENT handling:
+        #   If True, create a tree
+        #   If False, don't create a tree
+        #   If empty or missing, create a tree if a tree field is specified
+        tree = plot.current_tree()
         tree_edited = False
-        if data.get(self.model_fields.TREE_PRESENT, False):
+        tree_present = data.get(self.model_fields.TREE_PRESENT, None)
+        if tree_present:
             tree_edited = True
             if tree is None:
                 tree = Tree(instance=plot.instance)
 
-        self._commit_plot_data(data, plot)
-        self._commit_tree_data(data, plot, tree, tree_edited)
+        if tree_present or tree_present is None:
+            self._commit_tree_data(data, plot, tree, tree_edited)
 
         self.plot = plot
         self.status = TreeImportRow.SUCCESS

--- a/opentreemap/importer/tests.py
+++ b/opentreemap/importer/tests.py
@@ -1298,10 +1298,10 @@ class TreeIntegrationTests(IntegrationTests):
     def test_tree_present_works_as_expected(self):
         csv = """
         | point x | point y | tree present | diameter |
-        | 45.53   | 31.1    | false        |          |
+        | 45.53   | 31.1    | false        | 23       |
         | 45.63   | 32.1    | true         |          |
-        | 45.73   | 33.1    | true         | 23       |
-        | 45.93   | 33.1    | false        | 23       |
+        | 45.73   | 33.1    |              | 23       |
+        | 45.93   | 33.1    |              |          |
         """
 
         ieid = self.run_through_commit_views(csv)
@@ -1312,10 +1312,10 @@ class TreeIntegrationTests(IntegrationTests):
 
         self.assertEqual(
             tests,
-            [False,  # No tree data and tree present is false
-             True,   # Force a tree in this spot (tree present=true)
-             True,   # Data, so ignore tree present settings
-             True])  # Data, so ignore tree present settings
+            [False,  # tp=False means no tree even if data present
+             True,   # tp=True means tree even if no data present
+             True,   # tp missing means tree when data present
+             False]) # tp missing means no tree when no data present
 
     def test_common_name_matching(self):
         apple = Species(instance=self.instance, genus='malus',


### PR DESCRIPTION
Meaning of "Tree Present" values:
* False: don't create a tree even if tree data is present
* True: do create a tree even if no tree data is present
* blank value or column absent: create a tree only if tree data is present