### PR TITLE
Add tree favorites

### DIFF
--- a/opentreemap/otm1_migrator/migration_rules/standard_otm1.py
+++ b/opentreemap/otm1_migrator/migration_rules/standard_otm1.py
@@ -1,6 +1,5 @@
-from treemap.models import (User, Plot, Tree, Species,
-                            Audit, TreePhoto, Boundary,
-                            TreeFavorite)
+from treemap.models import (User, Plot, Tree, Species, Audit, TreePhoto,
+                            Boundary, Favorite)
 
 from otm_comments.models import EnhancedThreadedComment
 from registration.models import RegistrationProfile
@@ -210,11 +209,13 @@ MIGRATION_RULES = {
     },
     'treefavorite': {
         'command_line_flag': '-o',
-        'model_class': TreeFavorite,
+        'model_class': Favorite,
         'dependencies': {'user': 'user',
                          'tree': 'tree'},
         'renamed_fields': {'date_created': 'created'},
-        'common_fields': {'user', 'tree'}
+        'common_fields': {'user', 'tree'},
+        # We favorite Plots, not Trees in OTM2. This is handled in the save
+        'removed_fields': {'tree'},
     }
 }
 

--- a/opentreemap/otm1_migrator/model_processors.py
+++ b/opentreemap/otm1_migrator/model_processors.py
@@ -5,6 +5,7 @@ from __future__ import division
 
 import os
 import pytz
+from exceptions import NotImplementedError
 
 from django.db.transaction import atomic
 from django.contrib.contenttypes.models import ContentType
@@ -228,6 +229,13 @@ def save_audit(migration_rules, migration_event, relic_ids,
 @atomic
 def save_treefavorite(migration_rules, migration_event, fav_dict,
                       fav_obj, instance, **kwargs):
+    raise NotImplementedError(
+        'TreeFavorite to Favorite conversion has not been implemented yet!')
+# TODO: The following code is likely to work, but has not been tested at all.
+#     fav_obj.map_feature_id = (Tree
+#                               .objects
+#                               .values_list('plot__id', flat=True)
+#                               .get(pk=fav_dict.tree_id))
     fav_obj.save()
     fav_obj.created = inflate_date(fav_dict['fields']['date_created'])
     fav_obj.save()
@@ -236,7 +244,7 @@ def save_treefavorite(migration_rules, migration_event, fav_dict,
         instance=instance,
         migration_event=migration_event,
         otm1_model_id=fav_dict['pk'],
-        otm2_model_name='treefavorite',
+        otm2_model_name='favorite',
         otm2_model_id=fav_obj.pk)
 
     return fav_obj

--- a/opentreemap/treemap/lib/map_feature.py
+++ b/opentreemap/treemap/lib/map_feature.py
@@ -12,7 +12,7 @@ from django.db.models import Q
 
 from treemap.audit import Audit
 from treemap.ecobackend import ECOBENEFIT_ERRORS
-from treemap.models import Tree, MapFeature, User
+from treemap.models import Tree, MapFeature, User, Favorite
 
 from treemap.lib import format_benefits
 from treemap.lib.photo import context_dict_for_photo
@@ -281,6 +281,10 @@ def context_dict_for_map_feature(request, feature):
     user = request.user
     if user and user.is_authenticated():
         feature.mask_unauthorized_fields(user)
+        favorited = Favorite.objects \
+            .filter(map_feature=feature, user=user).exists()
+    else:
+        favorited = False
 
     feature.convert_to_display_units()
 
@@ -303,6 +307,7 @@ def context_dict_for_map_feature(request, feature):
         'address_full': feature.address_full,
         'upload_photo_endpoint': None,
         'photos': None,
+        'favorited': favorited
     }
 
     _add_eco_benefits_to_context_dict(instance, feature, context)

--- a/opentreemap/treemap/migrations/0091_auto__add_field_treefavorite_map_feature__chg_field_treefavorite_tree.py
+++ b/opentreemap/treemap/migrations/0091_auto__add_field_treefavorite_map_feature__chg_field_treefavorite_tree.py
@@ -1,0 +1,280 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'TreeFavorite.map_feature'
+        db.add_column(u'treemap_treefavorite', 'map_feature',
+                      self.gf('django.db.models.fields.related.ForeignKey')(to=orm['treemap.MapFeature'], null=True),
+                      keep_default=False)
+
+
+        # Changing field 'TreeFavorite.tree'
+        db.alter_column(u'treemap_treefavorite', 'tree_id', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['treemap.Tree'], null=True))
+
+    def backwards(self, orm):
+        # Deleting field 'TreeFavorite.map_feature'
+        db.delete_column(u'treemap_treefavorite', 'map_feature_id')
+
+
+        # Changing field 'TreeFavorite.tree'
+        db.alter_column(u'treemap_treefavorite', 'tree_id', self.gf('django.db.models.fields.related.ForeignKey')(default=None, to=orm['treemap.Tree']))
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'treemap.audit': {
+            'Meta': {'object_name': 'Audit'},
+            'action': ('django.db.models.fields.IntegerField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'current_value': ('django.db.models.fields.TextField', [], {'null': 'True', 'db_index': 'True'}),
+            'field': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']", 'null': 'True', 'blank': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'db_index': 'True'}),
+            'model_id': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'db_index': 'True'}),
+            'previous_value': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'ref': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Audit']", 'null': 'True'}),
+            'requires_auth': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.User']"})
+        },
+        u'treemap.benefitcurrencyconversion': {
+            'Meta': {'object_name': 'BenefitCurrencyConversion'},
+            'co2_lb_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'currency_symbol': ('django.db.models.fields.CharField', [], {'max_length': '5'}),
+            'electricity_kwh_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'h20_gal_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'natural_gas_kbtu_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'nox_lb_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'o3_lb_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'pm10_lb_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'sox_lb_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'voc_lb_to_currency': ('django.db.models.fields.FloatField', [], {})
+        },
+        u'treemap.boundary': {
+            'Meta': {'object_name': 'Boundary'},
+            'category': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'geom': ('django.contrib.gis.db.models.fields.MultiPolygonField', [], {'srid': '3857', 'db_column': "u'the_geom_webmercator'"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'sort_order': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'treemap.fieldpermission': {
+            'Meta': {'unique_together': "((u'model_name', u'field_name', u'role', u'instance'),)", 'object_name': 'FieldPermission'},
+            'field_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'model_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'permission_level': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'role': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Role']"})
+        },
+        u'treemap.instance': {
+            'Meta': {'object_name': 'Instance'},
+            'adjuncts_timestamp': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'basemap_data': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'basemap_type': ('django.db.models.fields.CharField', [], {'default': "u'google'", 'max_length': '255'}),
+            'boundaries': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['treemap.Boundary']", 'null': 'True', 'blank': 'True'}),
+            'bounds': ('django.contrib.gis.db.models.fields.MultiPolygonField', [], {'srid': '3857'}),
+            'center_override': ('django.contrib.gis.db.models.fields.PointField', [], {'srid': '3857', 'null': 'True', 'blank': 'True'}),
+            'config': ('treemap.json_field.JSONField', [], {'blank': 'True'}),
+            'default_role': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'default_role'", 'to': u"orm['treemap.Role']"}),
+            'eco_benefits_conversion': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.BenefitCurrencyConversion']", 'null': 'True', 'blank': 'True'}),
+            'geo_rev': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_public': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'itree_region_default': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'}),
+            'logo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'url_name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'users': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['treemap.User']", 'null': 'True', 'through': u"orm['treemap.InstanceUser']", 'blank': 'True'})
+        },
+        u'treemap.instanceuser': {
+            'Meta': {'unique_together': "((u'instance', u'user'),)", 'object_name': 'InstanceUser'},
+            'admin': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'reputation': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'role': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Role']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.User']"})
+        },
+        u'treemap.itreecodeoverride': {
+            'Meta': {'unique_together': "((u'instance_species', u'region'),)", 'object_name': 'ITreeCodeOverride'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance_species': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Species']"}),
+            'itree_code': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'region': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.ITreeRegion']"})
+        },
+        u'treemap.itreeregion': {
+            'Meta': {'object_name': 'ITreeRegion'},
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '40'}),
+            'geometry': ('django.contrib.gis.db.models.fields.MultiPolygonField', [], {'srid': '3857'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'treemap.mapfeature': {
+            'Meta': {'object_name': 'MapFeature'},
+            'address_city': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'address_street': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'address_zip': ('django.db.models.fields.CharField', [], {'max_length': '30', 'null': 'True', 'blank': 'True'}),
+            'feature_type': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'geom': ('django.contrib.gis.db.models.fields.PointField', [], {'srid': '3857', 'db_column': "u'the_geom_webmercator'"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'readonly': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'udfs': (u'treemap.udf.UDFField', [], {'db_index': 'True', 'blank': 'True'})
+        },
+        u'treemap.mapfeaturephoto': {
+            'Meta': {'object_name': 'MapFeaturePhoto'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'map_feature': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.MapFeature']"}),
+            'thumbnail': ('django.db.models.fields.files.ImageField', [], {'max_length': '100'})
+        },
+        u'treemap.plot': {
+            'Meta': {'object_name': 'Plot', '_ormbases': [u'treemap.MapFeature']},
+            'length': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            u'mapfeature_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['treemap.MapFeature']", 'unique': 'True', 'primary_key': 'True'}),
+            'owner_orig_id': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'width': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'treemap.reputationmetric': {
+            'Meta': {'object_name': 'ReputationMetric'},
+            'action': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'approval_score': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'denial_score': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'direct_write_score': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'model_name': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'treemap.role': {
+            'Meta': {'object_name': 'Role'},
+            'default_permission': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']", 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'rep_thresh': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'treemap.species': {
+            'Meta': {'unique_together': "((u'instance', u'common_name', u'genus', u'species', u'cultivar', u'other_part_of_name'),)", 'object_name': 'Species'},
+            'common_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'cultivar': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'fact_sheet_url': ('django.db.models.fields.URLField', [], {'max_length': '255', 'blank': 'True'}),
+            'fall_conspicuous': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'flower_conspicuous': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'flowering_period': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'fruit_or_nut_period': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'genus': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'has_wildlife_value': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'is_native': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'max_diameter': ('django.db.models.fields.IntegerField', [], {'default': '200'}),
+            'max_height': ('django.db.models.fields.IntegerField', [], {'default': '800'}),
+            'other_part_of_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'otm_code': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'palatable_human': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'plant_guide_url': ('django.db.models.fields.URLField', [], {'max_length': '255', 'blank': 'True'}),
+            'species': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'udfs': (u'treemap.udf.UDFField', [], {'db_index': 'True', 'blank': 'True'})
+        },
+        u'treemap.staticpage': {
+            'Meta': {'object_name': 'StaticPage'},
+            'content': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'treemap.tree': {
+            'Meta': {'object_name': 'Tree'},
+            'canopy_height': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'date_planted': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'date_removed': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'diameter': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'height': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'plot': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Plot']"}),
+            'readonly': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'species': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Species']", 'null': 'True', 'blank': 'True'}),
+            'udfs': (u'treemap.udf.UDFField', [], {'db_index': 'True', 'blank': 'True'})
+        },
+        u'treemap.treefavorite': {
+            'Meta': {'unique_together': "((u'user', u'tree'),)", 'object_name': 'TreeFavorite'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'map_feature': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.MapFeature']", 'null': 'True'}),
+            'tree': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Tree']", 'null': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.User']"})
+        },
+        u'treemap.treephoto': {
+            'Meta': {'object_name': 'TreePhoto', '_ormbases': [u'treemap.MapFeaturePhoto']},
+            u'mapfeaturephoto_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['treemap.MapFeaturePhoto']", 'unique': 'True', 'primary_key': 'True'}),
+            'tree': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Tree']"})
+        },
+        u'treemap.user': {
+            'Meta': {'object_name': 'User'},
+            'allow_email_contact': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'unique': 'True', 'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '30', 'blank': 'True'}),
+            'make_info_public': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'organization': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'photo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'thumbnail': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'treemap.userdefinedcollectionvalue': {
+            'Meta': {'object_name': 'UserDefinedCollectionValue'},
+            'data': (u'django_hstore.fields.DictionaryField', [], {}),
+            'field_definition': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.UserDefinedFieldDefinition']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model_id': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'treemap.userdefinedfielddefinition': {
+            'Meta': {'object_name': 'UserDefinedFieldDefinition'},
+            'datatype': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'iscollection': ('django.db.models.fields.BooleanField', [], {}),
+            'model_type': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        }
+    }
+
+    complete_apps = ['treemap']

--- a/opentreemap/treemap/migrations/0092_add_map_feature_to_tree_favorite.py
+++ b/opentreemap/treemap/migrations/0092_add_map_feature_to_tree_favorite.py
@@ -1,0 +1,274 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        for favorite in orm.TreeFavorite.objects.all():
+            favorite.map_feature_id = favorite.tree.plot_id
+            favorite.save()
+
+    def backwards(self, orm):
+        for favorite in orm.TreeFavorite.objects.all():
+            feature = favorite.map_feature
+            if feature.feature_type == 'Plot':
+                favorite.tree = orm.Tree.objects.get(plot_id=feature.id)
+                favorite.save()
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'treemap.audit': {
+            'Meta': {'object_name': 'Audit'},
+            'action': ('django.db.models.fields.IntegerField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'current_value': ('django.db.models.fields.TextField', [], {'null': 'True', 'db_index': 'True'}),
+            'field': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']", 'null': 'True', 'blank': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'db_index': 'True'}),
+            'model_id': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'db_index': 'True'}),
+            'previous_value': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'ref': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Audit']", 'null': 'True'}),
+            'requires_auth': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.User']"})
+        },
+        u'treemap.benefitcurrencyconversion': {
+            'Meta': {'object_name': 'BenefitCurrencyConversion'},
+            'co2_lb_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'currency_symbol': ('django.db.models.fields.CharField', [], {'max_length': '5'}),
+            'electricity_kwh_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'h20_gal_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'natural_gas_kbtu_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'nox_lb_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'o3_lb_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'pm10_lb_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'sox_lb_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'voc_lb_to_currency': ('django.db.models.fields.FloatField', [], {})
+        },
+        u'treemap.boundary': {
+            'Meta': {'object_name': 'Boundary'},
+            'category': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'geom': ('django.contrib.gis.db.models.fields.MultiPolygonField', [], {'srid': '3857', 'db_column': "u'the_geom_webmercator'"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'sort_order': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'treemap.fieldpermission': {
+            'Meta': {'unique_together': "((u'model_name', u'field_name', u'role', u'instance'),)", 'object_name': 'FieldPermission'},
+            'field_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'model_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'permission_level': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'role': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Role']"})
+        },
+        u'treemap.instance': {
+            'Meta': {'object_name': 'Instance'},
+            'adjuncts_timestamp': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'basemap_data': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'basemap_type': ('django.db.models.fields.CharField', [], {'default': "u'google'", 'max_length': '255'}),
+            'boundaries': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['treemap.Boundary']", 'null': 'True', 'blank': 'True'}),
+            'bounds': ('django.contrib.gis.db.models.fields.MultiPolygonField', [], {'srid': '3857'}),
+            'center_override': ('django.contrib.gis.db.models.fields.PointField', [], {'srid': '3857', 'null': 'True', 'blank': 'True'}),
+            'config': ('treemap.json_field.JSONField', [], {'blank': 'True'}),
+            'default_role': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'default_role'", 'to': u"orm['treemap.Role']"}),
+            'eco_benefits_conversion': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.BenefitCurrencyConversion']", 'null': 'True', 'blank': 'True'}),
+            'geo_rev': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_public': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'itree_region_default': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'}),
+            'logo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'url_name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'users': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['treemap.User']", 'null': 'True', 'through': u"orm['treemap.InstanceUser']", 'blank': 'True'})
+        },
+        u'treemap.instanceuser': {
+            'Meta': {'unique_together': "((u'instance', u'user'),)", 'object_name': 'InstanceUser'},
+            'admin': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'reputation': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'role': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Role']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.User']"})
+        },
+        u'treemap.itreecodeoverride': {
+            'Meta': {'unique_together': "((u'instance_species', u'region'),)", 'object_name': 'ITreeCodeOverride'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance_species': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Species']"}),
+            'itree_code': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'region': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.ITreeRegion']"})
+        },
+        u'treemap.itreeregion': {
+            'Meta': {'object_name': 'ITreeRegion'},
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '40'}),
+            'geometry': ('django.contrib.gis.db.models.fields.MultiPolygonField', [], {'srid': '3857'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'treemap.mapfeature': {
+            'Meta': {'object_name': 'MapFeature'},
+            'address_city': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'address_street': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'address_zip': ('django.db.models.fields.CharField', [], {'max_length': '30', 'null': 'True', 'blank': 'True'}),
+            'feature_type': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'geom': ('django.contrib.gis.db.models.fields.PointField', [], {'srid': '3857', 'db_column': "u'the_geom_webmercator'"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'readonly': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'udfs': (u'treemap.udf.UDFField', [], {'db_index': 'True', 'blank': 'True'})
+        },
+        u'treemap.mapfeaturephoto': {
+            'Meta': {'object_name': 'MapFeaturePhoto'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'map_feature': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.MapFeature']"}),
+            'thumbnail': ('django.db.models.fields.files.ImageField', [], {'max_length': '100'})
+        },
+        u'treemap.plot': {
+            'Meta': {'object_name': 'Plot', '_ormbases': [u'treemap.MapFeature']},
+            'length': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            u'mapfeature_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['treemap.MapFeature']", 'unique': 'True', 'primary_key': 'True'}),
+            'owner_orig_id': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'width': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'treemap.reputationmetric': {
+            'Meta': {'object_name': 'ReputationMetric'},
+            'action': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'approval_score': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'denial_score': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'direct_write_score': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'model_name': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'treemap.role': {
+            'Meta': {'object_name': 'Role'},
+            'default_permission': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']", 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'rep_thresh': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'treemap.species': {
+            'Meta': {'unique_together': "((u'instance', u'common_name', u'genus', u'species', u'cultivar', u'other_part_of_name'),)", 'object_name': 'Species'},
+            'common_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'cultivar': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'fact_sheet_url': ('django.db.models.fields.URLField', [], {'max_length': '255', 'blank': 'True'}),
+            'fall_conspicuous': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'flower_conspicuous': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'flowering_period': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'fruit_or_nut_period': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'genus': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'has_wildlife_value': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'is_native': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'max_diameter': ('django.db.models.fields.IntegerField', [], {'default': '200'}),
+            'max_height': ('django.db.models.fields.IntegerField', [], {'default': '800'}),
+            'other_part_of_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'otm_code': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'palatable_human': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'plant_guide_url': ('django.db.models.fields.URLField', [], {'max_length': '255', 'blank': 'True'}),
+            'species': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'udfs': (u'treemap.udf.UDFField', [], {'db_index': 'True', 'blank': 'True'})
+        },
+        u'treemap.staticpage': {
+            'Meta': {'object_name': 'StaticPage'},
+            'content': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'treemap.tree': {
+            'Meta': {'object_name': 'Tree'},
+            'canopy_height': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'date_planted': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'date_removed': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'diameter': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'height': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'plot': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Plot']"}),
+            'readonly': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'species': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Species']", 'null': 'True', 'blank': 'True'}),
+            'udfs': (u'treemap.udf.UDFField', [], {'db_index': 'True', 'blank': 'True'})
+        },
+        u'treemap.treefavorite': {
+            'Meta': {'unique_together': "((u'user', u'tree'),)", 'object_name': 'TreeFavorite'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'map_feature': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.MapFeature']", 'null': 'True'}),
+            'tree': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Tree']", 'null': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.User']"})
+        },
+        u'treemap.treephoto': {
+            'Meta': {'object_name': 'TreePhoto', '_ormbases': [u'treemap.MapFeaturePhoto']},
+            u'mapfeaturephoto_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['treemap.MapFeaturePhoto']", 'unique': 'True', 'primary_key': 'True'}),
+            'tree': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Tree']"})
+        },
+        u'treemap.user': {
+            'Meta': {'object_name': 'User'},
+            'allow_email_contact': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'unique': 'True', 'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '30', 'blank': 'True'}),
+            'make_info_public': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'organization': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'photo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'thumbnail': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'treemap.userdefinedcollectionvalue': {
+            'Meta': {'object_name': 'UserDefinedCollectionValue'},
+            'data': (u'django_hstore.fields.DictionaryField', [], {}),
+            'field_definition': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.UserDefinedFieldDefinition']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model_id': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'treemap.userdefinedfielddefinition': {
+            'Meta': {'object_name': 'UserDefinedFieldDefinition'},
+            'datatype': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'iscollection': ('django.db.models.fields.BooleanField', [], {}),
+            'model_type': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        }
+    }
+
+    complete_apps = ['treemap']
+    symmetrical = True

--- a/opentreemap/treemap/migrations/0093_auto__del_field_treefavorite_tree__chg_field_treefavorite_map_feature_.py
+++ b/opentreemap/treemap/migrations/0093_auto__del_field_treefavorite_tree__chg_field_treefavorite_map_feature_.py
@@ -1,0 +1,291 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Removing unique constraint on 'TreeFavorite', fields ['tree', 'user']
+        db.delete_unique(u'treemap_treefavorite', ['tree_id', 'user_id'])
+
+        # Deleting field 'TreeFavorite.tree'
+        db.delete_column(u'treemap_treefavorite', 'tree_id')
+
+
+        # Changing field 'TreeFavorite.map_feature'
+        db.alter_column(u'treemap_treefavorite', 'map_feature_id', self.gf('django.db.models.fields.related.ForeignKey')(default=None, to=orm['treemap.MapFeature']))
+        # Adding unique constraint on 'TreeFavorite', fields ['user', 'map_feature']
+        db.create_unique(u'treemap_treefavorite', ['user_id', 'map_feature_id'])
+
+
+    def backwards(self, orm):
+        # Removing unique constraint on 'TreeFavorite', fields ['user', 'map_feature']
+        db.delete_unique(u'treemap_treefavorite', ['user_id', 'map_feature_id'])
+
+        # Adding field 'TreeFavorite.tree'
+        db.add_column(u'treemap_treefavorite', 'tree',
+                      self.gf('django.db.models.fields.related.ForeignKey')(to=orm['treemap.Tree'], null=True),
+                      keep_default=False)
+
+
+        # Changing field 'TreeFavorite.map_feature'
+        db.alter_column(u'treemap_treefavorite', 'map_feature_id', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['treemap.MapFeature'], null=True))
+        # Adding unique constraint on 'TreeFavorite', fields ['tree', 'user']
+        db.create_unique(u'treemap_treefavorite', ['tree_id', 'user_id'])
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'treemap.audit': {
+            'Meta': {'object_name': 'Audit'},
+            'action': ('django.db.models.fields.IntegerField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'current_value': ('django.db.models.fields.TextField', [], {'null': 'True', 'db_index': 'True'}),
+            'field': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']", 'null': 'True', 'blank': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'db_index': 'True'}),
+            'model_id': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'db_index': 'True'}),
+            'previous_value': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'ref': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Audit']", 'null': 'True'}),
+            'requires_auth': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.User']"})
+        },
+        u'treemap.benefitcurrencyconversion': {
+            'Meta': {'object_name': 'BenefitCurrencyConversion'},
+            'co2_lb_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'currency_symbol': ('django.db.models.fields.CharField', [], {'max_length': '5'}),
+            'electricity_kwh_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'h20_gal_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'natural_gas_kbtu_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'nox_lb_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'o3_lb_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'pm10_lb_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'sox_lb_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'voc_lb_to_currency': ('django.db.models.fields.FloatField', [], {})
+        },
+        u'treemap.boundary': {
+            'Meta': {'object_name': 'Boundary'},
+            'category': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'geom': ('django.contrib.gis.db.models.fields.MultiPolygonField', [], {'srid': '3857', 'db_column': "u'the_geom_webmercator'"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'sort_order': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'treemap.fieldpermission': {
+            'Meta': {'unique_together': "((u'model_name', u'field_name', u'role', u'instance'),)", 'object_name': 'FieldPermission'},
+            'field_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'model_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'permission_level': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'role': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Role']"})
+        },
+        u'treemap.instance': {
+            'Meta': {'object_name': 'Instance'},
+            'adjuncts_timestamp': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'basemap_data': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'basemap_type': ('django.db.models.fields.CharField', [], {'default': "u'google'", 'max_length': '255'}),
+            'boundaries': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['treemap.Boundary']", 'null': 'True', 'blank': 'True'}),
+            'bounds': ('django.contrib.gis.db.models.fields.MultiPolygonField', [], {'srid': '3857'}),
+            'center_override': ('django.contrib.gis.db.models.fields.PointField', [], {'srid': '3857', 'null': 'True', 'blank': 'True'}),
+            'config': ('treemap.json_field.JSONField', [], {'blank': 'True'}),
+            'default_role': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'default_role'", 'to': u"orm['treemap.Role']"}),
+            'eco_benefits_conversion': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.BenefitCurrencyConversion']", 'null': 'True', 'blank': 'True'}),
+            'geo_rev': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_public': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'itree_region_default': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'}),
+            'logo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'url_name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'users': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['treemap.User']", 'null': 'True', 'through': u"orm['treemap.InstanceUser']", 'blank': 'True'})
+        },
+        u'treemap.instanceuser': {
+            'Meta': {'unique_together': "((u'instance', u'user'),)", 'object_name': 'InstanceUser'},
+            'admin': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'reputation': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'role': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Role']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.User']"})
+        },
+        u'treemap.itreecodeoverride': {
+            'Meta': {'unique_together': "((u'instance_species', u'region'),)", 'object_name': 'ITreeCodeOverride'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance_species': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Species']"}),
+            'itree_code': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'region': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.ITreeRegion']"})
+        },
+        u'treemap.itreeregion': {
+            'Meta': {'object_name': 'ITreeRegion'},
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '40'}),
+            'geometry': ('django.contrib.gis.db.models.fields.MultiPolygonField', [], {'srid': '3857'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'treemap.mapfeature': {
+            'Meta': {'object_name': 'MapFeature'},
+            'address_city': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'address_street': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'address_zip': ('django.db.models.fields.CharField', [], {'max_length': '30', 'null': 'True', 'blank': 'True'}),
+            'feature_type': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'geom': ('django.contrib.gis.db.models.fields.PointField', [], {'srid': '3857', 'db_column': "u'the_geom_webmercator'"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'readonly': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'udfs': (u'treemap.udf.UDFField', [], {'db_index': 'True', 'blank': 'True'})
+        },
+        u'treemap.mapfeaturephoto': {
+            'Meta': {'object_name': 'MapFeaturePhoto'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'map_feature': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.MapFeature']"}),
+            'thumbnail': ('django.db.models.fields.files.ImageField', [], {'max_length': '100'})
+        },
+        u'treemap.plot': {
+            'Meta': {'object_name': 'Plot', '_ormbases': [u'treemap.MapFeature']},
+            'length': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            u'mapfeature_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['treemap.MapFeature']", 'unique': 'True', 'primary_key': 'True'}),
+            'owner_orig_id': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'width': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'treemap.reputationmetric': {
+            'Meta': {'object_name': 'ReputationMetric'},
+            'action': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'approval_score': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'denial_score': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'direct_write_score': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'model_name': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'treemap.role': {
+            'Meta': {'object_name': 'Role'},
+            'default_permission': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']", 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'rep_thresh': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'treemap.species': {
+            'Meta': {'unique_together': "((u'instance', u'common_name', u'genus', u'species', u'cultivar', u'other_part_of_name'),)", 'object_name': 'Species'},
+            'common_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'cultivar': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'fact_sheet_url': ('django.db.models.fields.URLField', [], {'max_length': '255', 'blank': 'True'}),
+            'fall_conspicuous': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'flower_conspicuous': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'flowering_period': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'fruit_or_nut_period': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'genus': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'has_wildlife_value': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'is_native': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'max_diameter': ('django.db.models.fields.IntegerField', [], {'default': '200'}),
+            'max_height': ('django.db.models.fields.IntegerField', [], {'default': '800'}),
+            'other_part_of_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'otm_code': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'palatable_human': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'plant_guide_url': ('django.db.models.fields.URLField', [], {'max_length': '255', 'blank': 'True'}),
+            'species': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'udfs': (u'treemap.udf.UDFField', [], {'db_index': 'True', 'blank': 'True'})
+        },
+        u'treemap.staticpage': {
+            'Meta': {'object_name': 'StaticPage'},
+            'content': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'treemap.tree': {
+            'Meta': {'object_name': 'Tree'},
+            'canopy_height': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'date_planted': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'date_removed': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'diameter': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'height': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'plot': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Plot']"}),
+            'readonly': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'species': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Species']", 'null': 'True', 'blank': 'True'}),
+            'udfs': (u'treemap.udf.UDFField', [], {'db_index': 'True', 'blank': 'True'})
+        },
+        u'treemap.treefavorite': {
+            'Meta': {'unique_together': "((u'user', u'map_feature'),)", 'object_name': 'TreeFavorite'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'map_feature': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.MapFeature']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.User']"})
+        },
+        u'treemap.treephoto': {
+            'Meta': {'object_name': 'TreePhoto', '_ormbases': [u'treemap.MapFeaturePhoto']},
+            u'mapfeaturephoto_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['treemap.MapFeaturePhoto']", 'unique': 'True', 'primary_key': 'True'}),
+            'tree': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Tree']"})
+        },
+        u'treemap.user': {
+            'Meta': {'object_name': 'User'},
+            'allow_email_contact': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'unique': 'True', 'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '30', 'blank': 'True'}),
+            'make_info_public': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'organization': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'photo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'thumbnail': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'treemap.userdefinedcollectionvalue': {
+            'Meta': {'object_name': 'UserDefinedCollectionValue'},
+            'data': (u'django_hstore.fields.DictionaryField', [], {}),
+            'field_definition': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.UserDefinedFieldDefinition']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model_id': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'treemap.userdefinedfielddefinition': {
+            'Meta': {'object_name': 'UserDefinedFieldDefinition'},
+            'datatype': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'iscollection': ('django.db.models.fields.BooleanField', [], {}),
+            'model_type': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        }
+    }
+
+    complete_apps = ['treemap']

--- a/opentreemap/treemap/migrations/0094_auto__rename_treefavorite_favorite.py
+++ b/opentreemap/treemap/migrations/0094_auto__rename_treefavorite_favorite.py
@@ -1,0 +1,269 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        db.rename_table(u'treemap_treefavorite', u'treemap_favorite')
+
+
+    def backwards(self, orm):
+        db.rename_table(u'treemap_favorite', u'treemap_treefavorite')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'treemap.audit': {
+            'Meta': {'object_name': 'Audit'},
+            'action': ('django.db.models.fields.IntegerField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'current_value': ('django.db.models.fields.TextField', [], {'null': 'True', 'db_index': 'True'}),
+            'field': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']", 'null': 'True', 'blank': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'db_index': 'True'}),
+            'model_id': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'db_index': 'True'}),
+            'previous_value': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'ref': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Audit']", 'null': 'True'}),
+            'requires_auth': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.User']"})
+        },
+        u'treemap.benefitcurrencyconversion': {
+            'Meta': {'object_name': 'BenefitCurrencyConversion'},
+            'co2_lb_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'currency_symbol': ('django.db.models.fields.CharField', [], {'max_length': '5'}),
+            'electricity_kwh_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'h20_gal_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'natural_gas_kbtu_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'nox_lb_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'o3_lb_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'pm10_lb_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'sox_lb_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'voc_lb_to_currency': ('django.db.models.fields.FloatField', [], {})
+        },
+        u'treemap.boundary': {
+            'Meta': {'object_name': 'Boundary'},
+            'category': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'geom': ('django.contrib.gis.db.models.fields.MultiPolygonField', [], {'srid': '3857', 'db_column': "u'the_geom_webmercator'"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'sort_order': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'treemap.favorite': {
+            'Meta': {'unique_together': "((u'user', u'map_feature'),)", 'object_name': 'Favorite'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'map_feature': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.MapFeature']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.User']"})
+        },
+        u'treemap.fieldpermission': {
+            'Meta': {'unique_together': "((u'model_name', u'field_name', u'role', u'instance'),)", 'object_name': 'FieldPermission'},
+            'field_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'model_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'permission_level': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'role': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Role']"})
+        },
+        u'treemap.instance': {
+            'Meta': {'object_name': 'Instance'},
+            'adjuncts_timestamp': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'basemap_data': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'basemap_type': ('django.db.models.fields.CharField', [], {'default': "u'google'", 'max_length': '255'}),
+            'boundaries': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['treemap.Boundary']", 'null': 'True', 'blank': 'True'}),
+            'bounds': ('django.contrib.gis.db.models.fields.MultiPolygonField', [], {'srid': '3857'}),
+            'center_override': ('django.contrib.gis.db.models.fields.PointField', [], {'srid': '3857', 'null': 'True', 'blank': 'True'}),
+            'config': ('treemap.json_field.JSONField', [], {'blank': 'True'}),
+            'default_role': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'default_role'", 'to': u"orm['treemap.Role']"}),
+            'eco_benefits_conversion': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.BenefitCurrencyConversion']", 'null': 'True', 'blank': 'True'}),
+            'geo_rev': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_public': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'itree_region_default': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'}),
+            'logo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'url_name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'users': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['treemap.User']", 'null': 'True', 'through': u"orm['treemap.InstanceUser']", 'blank': 'True'})
+        },
+        u'treemap.instanceuser': {
+            'Meta': {'unique_together': "((u'instance', u'user'),)", 'object_name': 'InstanceUser'},
+            'admin': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'reputation': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'role': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Role']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.User']"})
+        },
+        u'treemap.itreecodeoverride': {
+            'Meta': {'unique_together': "((u'instance_species', u'region'),)", 'object_name': 'ITreeCodeOverride'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance_species': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Species']"}),
+            'itree_code': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'region': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.ITreeRegion']"})
+        },
+        u'treemap.itreeregion': {
+            'Meta': {'object_name': 'ITreeRegion'},
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '40'}),
+            'geometry': ('django.contrib.gis.db.models.fields.MultiPolygonField', [], {'srid': '3857'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'treemap.mapfeature': {
+            'Meta': {'object_name': 'MapFeature'},
+            'address_city': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'address_street': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'address_zip': ('django.db.models.fields.CharField', [], {'max_length': '30', 'null': 'True', 'blank': 'True'}),
+            'feature_type': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'geom': ('django.contrib.gis.db.models.fields.PointField', [], {'srid': '3857', 'db_column': "u'the_geom_webmercator'"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'readonly': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'udfs': (u'treemap.udf.UDFField', [], {'db_index': 'True', 'blank': 'True'})
+        },
+        u'treemap.mapfeaturephoto': {
+            'Meta': {'object_name': 'MapFeaturePhoto'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'map_feature': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.MapFeature']"}),
+            'thumbnail': ('django.db.models.fields.files.ImageField', [], {'max_length': '100'})
+        },
+        u'treemap.plot': {
+            'Meta': {'object_name': 'Plot', '_ormbases': [u'treemap.MapFeature']},
+            'length': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            u'mapfeature_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['treemap.MapFeature']", 'unique': 'True', 'primary_key': 'True'}),
+            'owner_orig_id': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'width': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'treemap.reputationmetric': {
+            'Meta': {'object_name': 'ReputationMetric'},
+            'action': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'approval_score': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'denial_score': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'direct_write_score': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'model_name': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'treemap.role': {
+            'Meta': {'object_name': 'Role'},
+            'default_permission': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']", 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'rep_thresh': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'treemap.species': {
+            'Meta': {'unique_together': "((u'instance', u'common_name', u'genus', u'species', u'cultivar', u'other_part_of_name'),)", 'object_name': 'Species'},
+            'common_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'cultivar': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'fact_sheet_url': ('django.db.models.fields.URLField', [], {'max_length': '255', 'blank': 'True'}),
+            'fall_conspicuous': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'flower_conspicuous': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'flowering_period': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'fruit_or_nut_period': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'genus': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'has_wildlife_value': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'is_native': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'max_diameter': ('django.db.models.fields.IntegerField', [], {'default': '200'}),
+            'max_height': ('django.db.models.fields.IntegerField', [], {'default': '800'}),
+            'other_part_of_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'otm_code': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'palatable_human': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'plant_guide_url': ('django.db.models.fields.URLField', [], {'max_length': '255', 'blank': 'True'}),
+            'species': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'udfs': (u'treemap.udf.UDFField', [], {'db_index': 'True', 'blank': 'True'})
+        },
+        u'treemap.staticpage': {
+            'Meta': {'object_name': 'StaticPage'},
+            'content': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'treemap.tree': {
+            'Meta': {'object_name': 'Tree'},
+            'canopy_height': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'date_planted': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'date_removed': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'diameter': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'height': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'plot': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Plot']"}),
+            'readonly': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'species': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Species']", 'null': 'True', 'blank': 'True'}),
+            'udfs': (u'treemap.udf.UDFField', [], {'db_index': 'True', 'blank': 'True'})
+        },
+        u'treemap.treephoto': {
+            'Meta': {'object_name': 'TreePhoto', '_ormbases': [u'treemap.MapFeaturePhoto']},
+            u'mapfeaturephoto_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['treemap.MapFeaturePhoto']", 'unique': 'True', 'primary_key': 'True'}),
+            'tree': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Tree']"})
+        },
+        u'treemap.user': {
+            'Meta': {'object_name': 'User'},
+            'allow_email_contact': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'unique': 'True', 'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '30', 'blank': 'True'}),
+            'make_info_public': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'organization': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'photo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'thumbnail': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'treemap.userdefinedcollectionvalue': {
+            'Meta': {'object_name': 'UserDefinedCollectionValue'},
+            'data': (u'django_hstore.fields.DictionaryField', [], {}),
+            'field_definition': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.UserDefinedFieldDefinition']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model_id': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'treemap.userdefinedfielddefinition': {
+            'Meta': {'object_name': 'UserDefinedFieldDefinition'},
+            'datatype': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'iscollection': ('django.db.models.fields.BooleanField', [], {}),
+            'model_type': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        }
+    }
+
+    complete_apps = ['treemap']

--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -840,13 +840,13 @@ class Tree(Convertible, UDFModel, PendingAuditable):
         super(Tree, self).delete_with_user(user, *args, **kwargs)
 
 
-class TreeFavorite(models.Model):
+class Favorite(models.Model):
     user = models.ForeignKey(User)
-    tree = models.ForeignKey(Tree)
+    map_feature = models.ForeignKey(MapFeature)
     created = models.DateTimeField(auto_now_add=True)
 
     class Meta:
-        unique_together = ('user', 'tree',)
+        unique_together = ('user', 'map_feature',)
 
 
 class MapFeaturePhoto(models.Model, PendingAuditable):

--- a/opentreemap/treemap/routes.py
+++ b/opentreemap/treemap/routes.py
@@ -149,6 +149,18 @@ add_map_feature_photo = add_map_feature_photo_do(
 rotate_map_feature_photo = add_map_feature_photo_do(
     feature_views.rotate_map_feature_photo)
 
+favorite_map_feature = do(
+    instance_request,
+    require_http_method('POST'),
+    json_api_edit,
+    feature_views.favorite_map_feature)
+
+unfavorite_map_feature = do(
+    instance_request,
+    require_http_method('POST'),
+    json_api_edit,
+    feature_views.unfavorite_map_feature)
+
 
 #####################################
 # plot

--- a/opentreemap/treemap/templates/treemap/map_feature_detail.html
+++ b/opentreemap/treemap/templates/treemap/map_feature_detail.html
@@ -61,7 +61,21 @@
     <div class="col-md-9">
       <div class="detail-header">
         <button class="btn share hidden">Share</button>
-        <h2 class="common-name" id="map-feature-title">{{ title }} <i id="favorite-star" class="icon-star-empty hidden"></i></h2>
+        <h2 class="common-name" id="map-feature-title">
+          {{ title }}
+          <a id="favorite-link"
+            data-href="{{ request.get_full_path }}"
+            data-is-favorited="{{ favorited }}"
+            data-always-enable="{{ request.user.is_authenticated }}"
+            data-favorite-url="{% url 'favorite_map_feature' instance_url_name=request.instance.url_name feature_id=feature.id %}"
+            data-unfavorite-url="{% url 'unfavorite_map_feature' instance_url_name=request.instance.url_name feature_id=feature.id %}">
+            {% if favorited %}
+              <i id="favorite-star" class="icon-star"></i>
+            {% else %}
+              <i id="favorite-star" class="icon-star-empty"></i>
+            {% endif %}
+          </a>
+        </h2>
         <h4 class="address" id="map-feature-address">{{ feature.address_full }}</h4>
       </div>
       <div class="row">

--- a/opentreemap/treemap/urls.py
+++ b/opentreemap/treemap/urls.py
@@ -51,6 +51,10 @@ urlpatterns = patterns(
         routes.map_feature_accordion, name='map_feature_accordion'),
     url('^features/(?P<feature_id>\d+)/photo/(?P<photo_id>\d+)$',
         routes.rotate_map_feature_photo, name='rotate_photo'),
+    url(r'^features/(?P<feature_id>\d+)/favorite$',
+        routes.favorite_map_feature, name='favorite_map_feature'),
+    url(r'^features/(?P<feature_id>\d+)/unfavorite$',
+        routes.unfavorite_map_feature, name='unfavorite_map_feature'),
 
     url(r'^plots/$', routes.add_map_feature, name='add_plot'),
     url(r'^plots/(?P<feature_id>\d+)/eco$',

--- a/opentreemap/treemap/views/map_feature.py
+++ b/opentreemap/treemap/views/map_feature.py
@@ -19,7 +19,7 @@ from opentreemap.util import dotted_split
 
 from treemap.units import Convertible
 from treemap.models import (Tree, Species, Instance, MapFeature,
-                            MapFeaturePhoto)
+                            MapFeaturePhoto, Favorite)
 from treemap.util import (package_field_errors, to_object_name)
 
 from treemap.images import get_image_from_request
@@ -291,3 +291,17 @@ def map_feature_popup(request, instance, feature_id):
     feature = get_map_feature_or_404(feature_id, instance)
     context = context_dict_for_map_feature(request, feature)
     return context
+
+
+def favorite_map_feature(request, instance, feature_id):
+    feature = get_map_feature_or_404(feature_id, instance)
+    Favorite.objects.get_or_create(user=request.user, map_feature=feature)
+
+    return {'success': True}
+
+
+def unfavorite_map_feature(request, instance, feature_id):
+    feature = get_map_feature_or_404(feature_id, instance)
+    Favorite.objects.filter(user=request.user, map_feature=feature).delete()
+
+    return {'success': True}


### PR DESCRIPTION
Builds on top of #1948

Adds a UI for favoriting trees, and converts the existing `TreeFavorite` model into a map feature based `Favorite` model.