### PR TITLE
Speed up instance edits page

### DIFF
--- a/opentreemap/treemap/lib/user.py
+++ b/opentreemap/treemap/lib/user.py
@@ -114,7 +114,9 @@ def get_audits(logged_in_user, instance, query_vars, user, models,
     query_vars = {k: v for (k, v) in query_vars.iteritems() if k != 'page'}
     next_page = None
     prev_page = None
-    if audits.count() == page_size:
+    # We are using len(audits) instead of audits.count() because we
+    # have already realized the queryset at this point
+    if len(audits) == page_size:
         query_vars['page'] = page + 1
         next_page = "?" + urllib.urlencode(query_vars)
     if page > 0:

--- a/opentreemap/treemap/lib/user.py
+++ b/opentreemap/treemap/lib/user.py
@@ -99,7 +99,7 @@ def get_audits(logged_in_user, instance, query_vars, user, models,
               .select_related('instance')
               .exclude(udf_bookkeeping_fields)
               .exclude(user=User.system_user())
-              .order_by('-created', 'id'))
+              .order_by('-created'))
 
     if user:
         audits = audits.filter(user=user)


### PR DESCRIPTION
There are two optimizations in this change set that reduce the query time of the instance edits page on my dev vm by 5x

```
Before: 10,700.12 ms (153 queries)
After:   2,741.48 ms (152 queries)
```
When the edits page was created as part of 369749a, an additional sort by id was added to the queryset. This technically produces more correct output, since the audits will be displayed in the exact order they were written to the table, but it causes a 5x slowdown in query execution time.

On my development wm with  5 million row audit table the filtered count query was taking 2 seconds to execute. I was able to remove the call to ``.count()`` entirely because a slice operator is applied to the queryset  earlier in the function, which realizes the quersets and allows us to use len()