### PR TITLE
Show different messages on empty favorites list

### DIFF
--- a/opentreemap/treemap/templates/treemap/user.html
+++ b/opentreemap/treemap/templates/treemap/user.html
@@ -116,7 +116,11 @@ active
                                 </li>
                             {% endfor %}
                         {% else %}
-                            <h4>{% trans "You have not starred any favorites yet." %}</h4>
+                            {% if its_me %}
+                                <h4>{% trans "You have not starred any favorites yet." %}</h4>
+                            {% else %}
+                                <h4>{% trans "This person has not starred any favorites yet." %}</h4>
+                            {% endif %}
                         {% endif %}
                     </ol>
                 </div>

--- a/opentreemap/treemap/views/user.py
+++ b/opentreemap/treemap/views/user.py
@@ -199,6 +199,7 @@ def user(request, username):
             private_fields.append(field_tuple)
 
     return {'user': user,
+            'its_me': user.id == request.user.id,
             'reputation': reputation,
             'instance_id': instance_id,
             'instances': get_user_instances(request.user, user, instance),


### PR DESCRIPTION
My profile page says "You" while other peoples' pages say "This person"

![screen shot 2015-02-25 at 1 53 30 pm](https://cloud.githubusercontent.com/assets/17363/6380396/8731b73c-bcf6-11e4-8bb7-46632ab3b7c7.png)

Fixes #1958 