### PR TITLE
Show different messages on empty favorites list

### DIFF
--- a/opentreemap/treemap/templates/treemap/user.html
+++ b/opentreemap/treemap/templates/treemap/user.html
@@ -116,7 +116,11 @@ active
                                 </li>
                             {% endfor %}
                         {% else %}
-                            <h4>{% trans "You have not starred any favorites yet." %}</h4>
+                            {% if its_me %}
+                                <h4>{% trans "You have not starred any favorites yet." %}</h4>
+                            {% else %}
+                                <h4>{% trans "This person has not starred any favorites yet." %}</h4>
+                            {% endif %}
                         {% endif %}
                     </ol>
                 </div>

--- a/opentreemap/treemap/views/user.py
+++ b/opentreemap/treemap/views/user.py
@@ -199,6 +199,7 @@ def user(request, username):
             private_fields.append(field_tuple)
 
     return {'user': user,
+            'its_me': user.id == request.user.id,
             'reputation': reputation,
             'instance_id': instance_id,
             'instances': get_user_instances(request.user, user, instance),


### PR DESCRIPTION
My profile page says "You" while other people's pages say "This person"

![profile](https://cloud.githubusercontent.com/assets/17363/6380422/c014ba18-bcf6-11e4-8bd5-e202c9dfe1ac.png)

Fixes #1958