### PR TITLE
Fix species list API double decoration error

### DIFF
--- a/opentreemap/api/tests.py
+++ b/opentreemap/api/tests.py
@@ -1773,3 +1773,17 @@ class PasswordResetTest(OTMTestCase):
         response = post_json(url % (API_PFX, self.jim.email),
                              {}, self.client, None)
         self.assertEquals(response.status_code, 200)
+
+
+class SpeciesListTest(OTMTestCase):
+    def setUp(self):
+        self.instance = setupTreemapEnv()
+        self.user = User.objects.get(username="jim")
+
+    def test_species_list_endpoint(self):
+        response = get_signed(
+            self.client,
+            "%s/instance/%s/species" % (API_PFX,
+                                        self.instance.url_name),
+            user=self.user)
+        self.assertEqual(response.status_code, 200)

--- a/opentreemap/api/views.py
+++ b/opentreemap/api/views.py
@@ -19,7 +19,7 @@ from django_tinsel.utils import decorate as do
 from django_tinsel.decorators import route, json_api_call
 
 from treemap.models import Plot, Tree, User
-from treemap.routes import species_list
+from treemap.views.misc import species_list
 from treemap.lib.map_feature import context_dict_for_plot
 from treemap.lib.tree import add_tree_photo_helper
 from treemap.lib.photo import context_dict_for_photo


### PR DESCRIPTION
The species list API endpoint was failing with a strange "Can't adapt type 'Instance'" error. It turns out this was caused by a refactor in
0eb39f023 which resulted in the species list endpoint being wrapped with the ``instance_request`` decorator twice.

Fixes #1964