### PR TITLE
Fix issues with invalid UDF names.

### DIFF
--- a/opentreemap/treemap/templatetags/form_extras.py
+++ b/opentreemap/treemap/templatetags/form_extras.py
@@ -26,8 +26,12 @@ register = template.Library()
 # Used to check that the identifier follows the format model.field or
 # model.udf:field name, can't be done in the grammar as it can't be checked
 # until looked up in the context
+#
+# We are being a little looser with our restrictions on UDF names here than
+# we are in the UDFD validation methods.  This regex is a sanity check, so it
+# is not essential that we are 100% accurate here
 _identifier_regex = re.compile(
-    r"^[a-zA-Z_.\-]+(?:udf\:[\w '\._-]+|[a-zA-Z0-9_\-]+)$")
+    r"^[a-zA-Z_.\-]+(?:udf\:.+|[a-zA-Z0-9_\-]+)$")
 
 FIELD_MAPPINGS = {
     'IntegerField': 'int',

--- a/opentreemap/treemap/tests/test_audit.py
+++ b/opentreemap/treemap/tests/test_audit.py
@@ -662,23 +662,23 @@ class PendingInsertTest(OTMTestCase):
             datatype=json.dumps({'type': 'choice',
                                  'choices': ['1', '2', '3']}),
             iscollection=False,
-            name='times_climbed')
+            name='times climbed')
 
         set_write_permissions(self.instance, self.commander_user,
-                              'Plot', ['udf:times_climbed'])
+                              'Plot', ['udf:times climbed'])
 
         FieldPermission.objects.create(
             model_name='Plot',
-            field_name='udf:times_climbed',
+            field_name='udf:times climbed',
             permission_level=FieldPermission.WRITE_WITH_AUDIT,
             role=self.pending_user.get_instance_user(self.instance).role,
             instance=self.instance)
 
         initial_plot = Plot(geom=self.p1, instance=self.instance)
-        initial_plot.udfs['times_climbed'] = '2'
+        initial_plot.udfs['times climbed'] = '2'
         initial_plot.save_with_user(self.pending_user)
 
-        udf_audit = Audit.objects.get(model='Plot', field='udf:times_climbed',
+        udf_audit = Audit.objects.get(model='Plot', field='udf:times climbed',
                                       model_id=initial_plot.pk)
         approve_or_reject_audit_and_apply(udf_audit, self.commander_user,
                                           approved=True)
@@ -704,7 +704,7 @@ class PendingInsertTest(OTMTestCase):
         self.assertEqual(new_plot.pk, initial_plot.pk)
         self.assertEqual(new_plot.readonly, False)
         self.assertEqual(new_plot.geom, self.p1)
-        self.assertEqual(new_plot.udfs['times_climbed'], '2')
+        self.assertEqual(new_plot.udfs['times climbed'], '2')
 
     def test_lots_of_trees_and_plots(self):
         """

--- a/opentreemap/treemap/tests/test_udfs.py
+++ b/opentreemap/treemap/tests/test_udfs.py
@@ -696,6 +696,31 @@ class UDFDefTest(OTMTestCase):
               'default': 'anything'}],
             iscollection=True)
 
+    def test_invalid_names(self):
+        with self.assertRaises(ValidationError):
+            UserDefinedFieldDefinition.objects.create(
+                instance=self.instance,
+                model_type='Plot',
+                datatype=json.dumps({'type': 'string'}),
+                iscollection=False,
+                name='%')
+
+        with self.assertRaises(ValidationError):
+            UserDefinedFieldDefinition.objects.create(
+                instance=self.instance,
+                model_type='Tree',
+                datatype=json.dumps({'type': 'string'}),
+                iscollection=False,
+                name='.')
+
+        with self.assertRaises(ValidationError):
+            UserDefinedFieldDefinition.objects.create(
+                instance=self.instance,
+                model_type='Plot',
+                datatype=json.dumps({'type': 'string'}),
+                iscollection=False,
+                name='__contains')
+
 
 class ScalarUDFTest(OTMTestCase):
 


### PR DESCRIPTION
Adds validation that prevents UDFs from being created if their name contains
any problematic characters.  I tried every special character on a US keyboard
and only found issues with '%', '_', and '.'

'%' and '__' both cause issues for the Django ORM, preventing us from querying
for those UDFs by name.
'.' causes issues when attempting to render the Plot Detail

Also loosens restrictions on UDF names used by the form_extras template tags,
to allow any characters.

Fixes #1765