### PR TITLE
Add updated_at to MapFeature

### DIFF
--- a/opentreemap/treemap/lib/__init__.py
+++ b/opentreemap/treemap/lib/__init__.py
@@ -5,6 +5,7 @@ from __future__ import division
 
 import re
 
+from django.db import connection
 from django.utils.formats import number_format
 
 from treemap.units import get_units, get_display_value
@@ -53,3 +54,11 @@ def get_function_by_path(fn_path):
     mod = __import__(modulepath, fromlist=[fcn])
 
     return getattr(mod, fcn)
+
+
+def execute_sql(sql):
+    cursor = connection.cursor()
+    try:
+        cursor.execute(sql)
+    finally:
+        cursor.close()

--- a/opentreemap/treemap/management/commands/set_mapfeature_updated_at.py
+++ b/opentreemap/treemap/management/commands/set_mapfeature_updated_at.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from django.core.management.base import BaseCommand
+
+from treemap.lib.map_feature import set_map_feature_updated_at
+
+
+class Command(BaseCommand):
+    """
+    Sets the value of MapFeature.updated_at based on the content of the
+    treemap_audit table
+    """
+    def handle(self, *args, **options):
+        print('If you have a large database, the queries run by this command '
+              'may take a while to complete')
+        set_map_feature_updated_at()

--- a/opentreemap/treemap/migrations/0095_auto__add_field_mapfeature_updated_at.py
+++ b/opentreemap/treemap/migrations/0095_auto__add_field_mapfeature_updated_at.py
@@ -1,0 +1,273 @@
+# -*- coding: utf-8 -*-
+from south.db import db
+from south.v2 import SchemaMigration
+from django.utils import timezone
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'MapFeature.updated_at'
+        db.add_column(u'treemap_mapfeature', 'updated_at',
+                      self.gf('django.db.models.fields.DateTimeField')(default=timezone.now),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'MapFeature.updated_at'
+        db.delete_column(u'treemap_mapfeature', 'updated_at')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'treemap.audit': {
+            'Meta': {'object_name': 'Audit'},
+            'action': ('django.db.models.fields.IntegerField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'current_value': ('django.db.models.fields.TextField', [], {'null': 'True', 'db_index': 'True'}),
+            'field': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']", 'null': 'True', 'blank': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'db_index': 'True'}),
+            'model_id': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'db_index': 'True'}),
+            'previous_value': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'ref': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Audit']", 'null': 'True'}),
+            'requires_auth': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.User']"})
+        },
+        u'treemap.benefitcurrencyconversion': {
+            'Meta': {'object_name': 'BenefitCurrencyConversion'},
+            'co2_lb_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'currency_symbol': ('django.db.models.fields.CharField', [], {'max_length': '5'}),
+            'electricity_kwh_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'h20_gal_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'natural_gas_kbtu_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'nox_lb_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'o3_lb_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'pm10_lb_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'sox_lb_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'voc_lb_to_currency': ('django.db.models.fields.FloatField', [], {})
+        },
+        u'treemap.boundary': {
+            'Meta': {'object_name': 'Boundary'},
+            'category': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'geom': ('django.contrib.gis.db.models.fields.MultiPolygonField', [], {'srid': '3857', 'db_column': "u'the_geom_webmercator'"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'sort_order': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'treemap.favorite': {
+            'Meta': {'unique_together': "((u'user', u'map_feature'),)", 'object_name': 'Favorite'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'map_feature': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.MapFeature']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.User']"})
+        },
+        u'treemap.fieldpermission': {
+            'Meta': {'unique_together': "((u'model_name', u'field_name', u'role', u'instance'),)", 'object_name': 'FieldPermission'},
+            'field_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'model_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'permission_level': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'role': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Role']"})
+        },
+        u'treemap.instance': {
+            'Meta': {'object_name': 'Instance'},
+            'adjuncts_timestamp': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'basemap_data': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'basemap_type': ('django.db.models.fields.CharField', [], {'default': "u'google'", 'max_length': '255'}),
+            'boundaries': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['treemap.Boundary']", 'null': 'True', 'blank': 'True'}),
+            'bounds': ('django.contrib.gis.db.models.fields.MultiPolygonField', [], {'srid': '3857'}),
+            'center_override': ('django.contrib.gis.db.models.fields.PointField', [], {'srid': '3857', 'null': 'True', 'blank': 'True'}),
+            'config': ('treemap.json_field.JSONField', [], {'blank': 'True'}),
+            'default_role': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'default_role'", 'to': u"orm['treemap.Role']"}),
+            'eco_benefits_conversion': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.BenefitCurrencyConversion']", 'null': 'True', 'blank': 'True'}),
+            'geo_rev': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_public': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'itree_region_default': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'}),
+            'logo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'url_name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'users': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['treemap.User']", 'null': 'True', 'through': u"orm['treemap.InstanceUser']", 'blank': 'True'})
+        },
+        u'treemap.instanceuser': {
+            'Meta': {'unique_together': "((u'instance', u'user'),)", 'object_name': 'InstanceUser'},
+            'admin': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'reputation': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'role': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Role']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.User']"})
+        },
+        u'treemap.itreecodeoverride': {
+            'Meta': {'unique_together': "((u'instance_species', u'region'),)", 'object_name': 'ITreeCodeOverride'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance_species': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Species']"}),
+            'itree_code': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'region': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.ITreeRegion']"})
+        },
+        u'treemap.itreeregion': {
+            'Meta': {'object_name': 'ITreeRegion'},
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '40'}),
+            'geometry': ('django.contrib.gis.db.models.fields.MultiPolygonField', [], {'srid': '3857'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'treemap.mapfeature': {
+            'Meta': {'object_name': 'MapFeature'},
+            'address_city': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'address_street': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'address_zip': ('django.db.models.fields.CharField', [], {'max_length': '30', 'null': 'True', 'blank': 'True'}),
+            'feature_type': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'geom': ('django.contrib.gis.db.models.fields.PointField', [], {'srid': '3857', 'db_column': "u'the_geom_webmercator'"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'readonly': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'udfs': (u'treemap.udf.UDFField', [], {'db_index': 'True', 'blank': 'True'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'})
+        },
+        u'treemap.mapfeaturephoto': {
+            'Meta': {'object_name': 'MapFeaturePhoto'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'map_feature': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.MapFeature']"}),
+            'thumbnail': ('django.db.models.fields.files.ImageField', [], {'max_length': '100'})
+        },
+        u'treemap.plot': {
+            'Meta': {'object_name': 'Plot', '_ormbases': [u'treemap.MapFeature']},
+            'length': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            u'mapfeature_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['treemap.MapFeature']", 'unique': 'True', 'primary_key': 'True'}),
+            'owner_orig_id': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'width': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'treemap.reputationmetric': {
+            'Meta': {'object_name': 'ReputationMetric'},
+            'action': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'approval_score': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'denial_score': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'direct_write_score': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'model_name': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'treemap.role': {
+            'Meta': {'object_name': 'Role'},
+            'default_permission': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']", 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'rep_thresh': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'treemap.species': {
+            'Meta': {'unique_together': "((u'instance', u'common_name', u'genus', u'species', u'cultivar', u'other_part_of_name'),)", 'object_name': 'Species'},
+            'common_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'cultivar': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'fact_sheet_url': ('django.db.models.fields.URLField', [], {'max_length': '255', 'blank': 'True'}),
+            'fall_conspicuous': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'flower_conspicuous': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'flowering_period': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'fruit_or_nut_period': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'genus': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'has_wildlife_value': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'is_native': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'max_diameter': ('django.db.models.fields.IntegerField', [], {'default': '200'}),
+            'max_height': ('django.db.models.fields.IntegerField', [], {'default': '800'}),
+            'other_part_of_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'otm_code': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'palatable_human': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'plant_guide_url': ('django.db.models.fields.URLField', [], {'max_length': '255', 'blank': 'True'}),
+            'species': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'udfs': (u'treemap.udf.UDFField', [], {'db_index': 'True', 'blank': 'True'})
+        },
+        u'treemap.staticpage': {
+            'Meta': {'object_name': 'StaticPage'},
+            'content': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'treemap.tree': {
+            'Meta': {'object_name': 'Tree'},
+            'canopy_height': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'date_planted': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'date_removed': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'diameter': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'height': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'plot': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Plot']"}),
+            'readonly': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'species': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Species']", 'null': 'True', 'blank': 'True'}),
+            'udfs': (u'treemap.udf.UDFField', [], {'db_index': 'True', 'blank': 'True'})
+        },
+        u'treemap.treephoto': {
+            'Meta': {'object_name': 'TreePhoto', '_ormbases': [u'treemap.MapFeaturePhoto']},
+            u'mapfeaturephoto_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['treemap.MapFeaturePhoto']", 'unique': 'True', 'primary_key': 'True'}),
+            'tree': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Tree']"})
+        },
+        u'treemap.user': {
+            'Meta': {'object_name': 'User'},
+            'allow_email_contact': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'unique': 'True', 'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '30', 'blank': 'True'}),
+            'make_info_public': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'organization': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'photo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'thumbnail': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'treemap.userdefinedcollectionvalue': {
+            'Meta': {'object_name': 'UserDefinedCollectionValue'},
+            'data': (u'django_hstore.fields.DictionaryField', [], {}),
+            'field_definition': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.UserDefinedFieldDefinition']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model_id': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'treemap.userdefinedfielddefinition': {
+            'Meta': {'object_name': 'UserDefinedFieldDefinition'},
+            'datatype': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'iscollection': ('django.db.models.fields.BooleanField', [], {}),
+            'model_type': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        }
+    }
+
+    complete_apps = ['treemap']

--- a/opentreemap/treemap/migrations/0096_set_mapfeature_updated_at.py
+++ b/opentreemap/treemap/migrations/0096_set_mapfeature_updated_at.py
@@ -1,0 +1,269 @@
+# -*- coding: utf-8 -*-
+from south.v2 import DataMigration
+
+from treemap.lib.map_feature import set_map_feature_updated_at
+
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        set_map_feature_updated_at()
+
+    def backwards(self, orm):
+        print('WARNING: No backwards action taken. This migration is not '
+              'reversible, but it can be re-run')
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'treemap.audit': {
+            'Meta': {'object_name': 'Audit'},
+            'action': ('django.db.models.fields.IntegerField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'current_value': ('django.db.models.fields.TextField', [], {'null': 'True', 'db_index': 'True'}),
+            'field': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']", 'null': 'True', 'blank': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'db_index': 'True'}),
+            'model_id': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'db_index': 'True'}),
+            'previous_value': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'ref': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Audit']", 'null': 'True'}),
+            'requires_auth': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.User']"})
+        },
+        u'treemap.benefitcurrencyconversion': {
+            'Meta': {'object_name': 'BenefitCurrencyConversion'},
+            'co2_lb_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'currency_symbol': ('django.db.models.fields.CharField', [], {'max_length': '5'}),
+            'electricity_kwh_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'h20_gal_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'natural_gas_kbtu_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'nox_lb_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'o3_lb_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'pm10_lb_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'sox_lb_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'voc_lb_to_currency': ('django.db.models.fields.FloatField', [], {})
+        },
+        u'treemap.boundary': {
+            'Meta': {'object_name': 'Boundary'},
+            'category': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'geom': ('django.contrib.gis.db.models.fields.MultiPolygonField', [], {'srid': '3857', 'db_column': "u'the_geom_webmercator'"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'sort_order': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'treemap.favorite': {
+            'Meta': {'unique_together': "((u'user', u'map_feature'),)", 'object_name': 'Favorite'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'map_feature': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.MapFeature']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.User']"})
+        },
+        u'treemap.fieldpermission': {
+            'Meta': {'unique_together': "((u'model_name', u'field_name', u'role', u'instance'),)", 'object_name': 'FieldPermission'},
+            'field_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'model_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'permission_level': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'role': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Role']"})
+        },
+        u'treemap.instance': {
+            'Meta': {'object_name': 'Instance'},
+            'adjuncts_timestamp': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'basemap_data': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'basemap_type': ('django.db.models.fields.CharField', [], {'default': "u'google'", 'max_length': '255'}),
+            'boundaries': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['treemap.Boundary']", 'null': 'True', 'blank': 'True'}),
+            'bounds': ('django.contrib.gis.db.models.fields.MultiPolygonField', [], {'srid': '3857'}),
+            'center_override': ('django.contrib.gis.db.models.fields.PointField', [], {'srid': '3857', 'null': 'True', 'blank': 'True'}),
+            'config': ('treemap.json_field.JSONField', [], {'blank': 'True'}),
+            'default_role': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'default_role'", 'to': u"orm['treemap.Role']"}),
+            'eco_benefits_conversion': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.BenefitCurrencyConversion']", 'null': 'True', 'blank': 'True'}),
+            'geo_rev': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_public': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'itree_region_default': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'}),
+            'logo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'url_name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'users': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['treemap.User']", 'null': 'True', 'through': u"orm['treemap.InstanceUser']", 'blank': 'True'})
+        },
+        u'treemap.instanceuser': {
+            'Meta': {'unique_together': "((u'instance', u'user'),)", 'object_name': 'InstanceUser'},
+            'admin': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'reputation': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'role': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Role']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.User']"})
+        },
+        u'treemap.itreecodeoverride': {
+            'Meta': {'unique_together': "((u'instance_species', u'region'),)", 'object_name': 'ITreeCodeOverride'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance_species': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Species']"}),
+            'itree_code': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'region': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.ITreeRegion']"})
+        },
+        u'treemap.itreeregion': {
+            'Meta': {'object_name': 'ITreeRegion'},
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '40'}),
+            'geometry': ('django.contrib.gis.db.models.fields.MultiPolygonField', [], {'srid': '3857'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'treemap.mapfeature': {
+            'Meta': {'object_name': 'MapFeature'},
+            'address_city': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'address_street': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'address_zip': ('django.db.models.fields.CharField', [], {'max_length': '30', 'null': 'True', 'blank': 'True'}),
+            'feature_type': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'geom': ('django.contrib.gis.db.models.fields.PointField', [], {'srid': '3857', 'db_column': "u'the_geom_webmercator'"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'readonly': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'udfs': (u'treemap.udf.UDFField', [], {'db_index': 'True', 'blank': 'True'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'})
+        },
+        u'treemap.mapfeaturephoto': {
+            'Meta': {'object_name': 'MapFeaturePhoto'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'map_feature': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.MapFeature']"}),
+            'thumbnail': ('django.db.models.fields.files.ImageField', [], {'max_length': '100'})
+        },
+        u'treemap.plot': {
+            'Meta': {'object_name': 'Plot', '_ormbases': [u'treemap.MapFeature']},
+            'length': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            u'mapfeature_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['treemap.MapFeature']", 'unique': 'True', 'primary_key': 'True'}),
+            'owner_orig_id': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'width': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'treemap.reputationmetric': {
+            'Meta': {'object_name': 'ReputationMetric'},
+            'action': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'approval_score': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'denial_score': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'direct_write_score': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'model_name': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'treemap.role': {
+            'Meta': {'object_name': 'Role'},
+            'default_permission': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']", 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'rep_thresh': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'treemap.species': {
+            'Meta': {'unique_together': "((u'instance', u'common_name', u'genus', u'species', u'cultivar', u'other_part_of_name'),)", 'object_name': 'Species'},
+            'common_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'cultivar': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'fact_sheet_url': ('django.db.models.fields.URLField', [], {'max_length': '255', 'blank': 'True'}),
+            'fall_conspicuous': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'flower_conspicuous': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'flowering_period': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'fruit_or_nut_period': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'genus': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'has_wildlife_value': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'is_native': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'max_diameter': ('django.db.models.fields.IntegerField', [], {'default': '200'}),
+            'max_height': ('django.db.models.fields.IntegerField', [], {'default': '800'}),
+            'other_part_of_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'otm_code': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'palatable_human': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'plant_guide_url': ('django.db.models.fields.URLField', [], {'max_length': '255', 'blank': 'True'}),
+            'species': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'udfs': (u'treemap.udf.UDFField', [], {'db_index': 'True', 'blank': 'True'})
+        },
+        u'treemap.staticpage': {
+            'Meta': {'object_name': 'StaticPage'},
+            'content': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'treemap.tree': {
+            'Meta': {'object_name': 'Tree'},
+            'canopy_height': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'date_planted': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'date_removed': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'diameter': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'height': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'plot': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Plot']"}),
+            'readonly': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'species': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Species']", 'null': 'True', 'blank': 'True'}),
+            'udfs': (u'treemap.udf.UDFField', [], {'db_index': 'True', 'blank': 'True'})
+        },
+        u'treemap.treephoto': {
+            'Meta': {'object_name': 'TreePhoto', '_ormbases': [u'treemap.MapFeaturePhoto']},
+            u'mapfeaturephoto_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['treemap.MapFeaturePhoto']", 'unique': 'True', 'primary_key': 'True'}),
+            'tree': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Tree']"})
+        },
+        u'treemap.user': {
+            'Meta': {'object_name': 'User'},
+            'allow_email_contact': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'unique': 'True', 'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '30', 'blank': 'True'}),
+            'make_info_public': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'organization': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'photo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'thumbnail': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'treemap.userdefinedcollectionvalue': {
+            'Meta': {'object_name': 'UserDefinedCollectionValue'},
+            'data': (u'django_hstore.fields.DictionaryField', [], {}),
+            'field_definition': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.UserDefinedFieldDefinition']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model_id': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'treemap.userdefinedfielddefinition': {
+            'Meta': {'object_name': 'UserDefinedFieldDefinition'},
+            'datatype': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'iscollection': ('django.db.models.fields.BooleanField', [], {}),
+            'model_type': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        }
+    }
+
+    complete_apps = ['treemap']
+    symmetrical = True

--- a/opentreemap/treemap/tests/test_map_feature.py
+++ b/opentreemap/treemap/tests/test_map_feature.py
@@ -73,3 +73,44 @@ class PlotHashTestCase(OTMTestCase):
         self.assertEqual(self.final_plot_hash,
                          self.final_map_feature_hash,
                          same_hash_msg)
+
+
+class UpdatedAtTest(OTMTestCase):
+
+    def setUp(self):
+        self.point = Point(-8515941.0, 4953519.0)
+        self.instance = make_instance(point=self.point)
+        self.user = make_commander_user(self.instance)
+        self.plot = Plot(geom=self.point, instance=self.instance)
+        self.plot.save_with_user(self.user)
+        self.plot = Plot.objects.get(pk=self.plot.pk)
+        self.initial_updated = self.plot.updated_at
+
+    def test_update_sets_updated(self):
+        self.plot.width = 22
+        self.plot.save_with_user(self.user)
+        self.assertGreater(self.plot.updated_at, self.initial_updated)
+
+    def test_add_tree_sets_updated(self):
+        tree = Tree(diameter=10, plot=self.plot, instance=self.instance)
+        tree.save_with_user(self.user)
+        self.assertGreater(self.plot.updated_at, self.initial_updated)
+
+    def test_update_tree_sets_updated(self):
+        tree = Tree(diameter=10, plot=self.plot, instance=self.instance)
+        tree.save_with_user(self.user)
+        self.plot = Plot.objects.get(pk=self.plot.pk)
+        self.inital_updated = self.plot.updated_at
+
+        tree.height = 22
+        tree.save_with_user(self.user)
+        self.assertGreater(self.plot.updated_at, self.initial_updated)
+
+    def test_delete_tree_sets_updated(self):
+        tree = Tree(diameter=10, plot=self.plot, instance=self.instance)
+        tree.save_with_user(self.user)
+        self.plot = Plot.objects.get(pk=self.plot.pk)
+        self.inital_updated = self.plot.updated_at
+
+        tree.delete_with_user(self.user)
+        self.assertGreater(self.plot.updated_at, self.initial_updated)

--- a/opentreemap/treemap/tests/test_updated_at.py
+++ b/opentreemap/treemap/tests/test_updated_at.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+import pytz
+
+from datetime import datetime, timedelta
+
+from django.contrib.gis.geos import Point
+from django.db.models import Q
+from django.utils import timezone
+
+from treemap.lib import execute_sql
+from treemap.lib.map_feature import set_map_feature_updated_at
+from treemap.models import Tree, Plot, Audit
+from treemap.tests import (LocalMediaTestCase, make_instance,
+                           make_commander_user)
+
+
+class UpdatedAtTestCase(LocalMediaTestCase):
+    def setUp(self):
+        super(UpdatedAtTestCase, self).setUp()
+        self.image = self.load_resource('tree1.gif')
+        self.test_start = timezone.now()
+        self.point = Point(-8515941.0, 4953519.0)
+        self.instance = make_instance(point=self.point)
+        self.user = make_commander_user(self.instance)
+        self.plot = Plot(geom=self.point, instance=self.instance)
+        self.plot.save_with_user(self.user)
+
+    def reload_members(self):
+        self.plot = Plot.objects.get(pk=self.plot.pk)
+
+    def max_audit_for_model_type(self, models):
+        if isinstance(models, basestring):
+            models = [models]
+        model_q = Q()
+        for model in models:
+            model_q |= Q(model=model)
+        audits = Audit.objects.filter(model_q)\
+                              .order_by('-created')
+
+        if audits:
+            return audits[0]
+
+    def clear_updated_at(self):
+        # to_timestamp(0) is the unix epoch 1970-1-1 00:00
+        execute_sql(
+            "UPDATE treemap_mapfeature SET updated_at = to_timestamp(0);")
+
+    def clear_and_set_and_reload(self):
+        self.clear_updated_at()
+        set_map_feature_updated_at()
+        self.reload_members()
+
+    def test_helpers(self):
+        self.clear_updated_at()
+        self.reload_members()
+        self.assertEqual(self.plot.updated_at,
+                         datetime(1970, 1, 1, tzinfo=pytz.UTC))
+
+    def test_map_feature_is_updated(self):
+        self.clear_and_set_and_reload()
+        self.assertGreater(self.plot.updated_at, self.test_start)
+
+    def test_tree_overrides_plot(self):
+        tree = Tree(diameter=10, plot=self.plot, instance=self.instance)
+        tree.save_with_user(self.user)
+
+        tree_audit = self.max_audit_for_model_type('Tree')
+        plot_audit = self.max_audit_for_model_type('Plot')
+        # Backdate the plot audit so it is definitely older than the tree audit
+        plot_audit.created = tree_audit.created - timedelta(days=1)
+        plot_audit.save()
+
+        self.clear_and_set_and_reload()
+        self.assertEqual(self.plot.updated_at, tree_audit.created)
+
+    def test_treephoto_overrides_tree_and_plot_updated(self):
+        tree = Tree(diameter=10, plot=self.plot, instance=self.instance)
+        tree.save_with_user(self.user)
+        tree.add_photo(self.image, self.user)
+
+        tree_audit = self.max_audit_for_model_type('Tree')
+        treephoto_audit = self.max_audit_for_model_type(['MapFeaturePhoto',
+                                                         'TreePhoto'])
+        plot_audit = self.max_audit_for_model_type('Plot')
+        # Backdate the audits so photo it is definitely the newsest
+        plot_audit.created = treephoto_audit.created - timedelta(days=2)
+        plot_audit.save()
+        tree_audit.created = treephoto_audit.created - timedelta(days=1)
+        tree_audit.save()
+
+        self.clear_and_set_and_reload()
+        self.assertEqual(self.plot.updated_at, treephoto_audit.created)

--- a/opentreemap/treemap/tests/test_views.py
+++ b/opentreemap/treemap/tests/test_views.py
@@ -191,6 +191,27 @@ class TreePhotoTestCase(LocalMediaTestCase):
         self.image = self.load_resource('tree1.gif')
 
 
+class TreePhotoAffectsPlotUpdatedAtTestCase(TreePhotoTestCase):
+    def setUp(self):
+        super(TreePhotoAffectsPlotUpdatedAtTestCase, self).setUp()
+        self.initial_updated = self.plot.updated_at
+
+    def test_add_photo_sets_updated(self):
+        self.tree.add_photo(self.image, self.user)
+        self.assertGreater(self.plot.updated_at, self.initial_updated)
+
+    def test_delete_photo_sets_updated(self):
+        self.tree.add_photo(self.image, self.user)
+        self.plot = Plot.objects.get(pk=self.plot.pk)
+        self.initial_updated = self.plot.updated_at
+
+        photo = self.plot.current_tree().photos()[0]
+        photo.delete_with_user(self.user)
+
+        self.plot = Plot.objects.get(pk=self.plot.pk)
+        self.assertGreater(self.plot.updated_at, self.initial_updated)
+
+
 class TreePhotoRotationTest(TreePhotoTestCase):
     def setUp(self):
         super(TreePhotoRotationTest, self).setUp()


### PR DESCRIPTION
We have decided to keep a denormalized copy of the time each MapFeature was last updated to facilitate simple querying. This commit adds a new updated_at field and functionality to keep it maintained.

Managing updates to this new field when only a child object changes (Tree, Photo, etc.) is tricky. I opted to target the easily findable save methods and add a call to a new function that updates the parent MapFeature row directly, rather than depend on save_with_user being called on the MapFeature instance when none of the properties of that object have changed.

Adding updated_at created an interesting field permission wrinkle. I did not want to have to create explicit permission objects to control this "special" field. Adding a tree photo will require permission to edit updated_at, even if the user has no other writable permissions on that object, so I opted to use a class-level property to flag a field as being world writable.

I implemented the backfilling of updated_at values with raw SQL queries for efficiency. Running the function with 500k map features and 5.6m audit records takes < 3 minutes. I also find the nested joins in the SQL queries easier to understand than complex ORM calls.

Fixes #1972