### PR TITLE
Add Last updated at to advanced search

### DIFF
--- a/opentreemap/treemap/audit.py
+++ b/opentreemap/treemap/audit.py
@@ -743,7 +743,6 @@ class Authorizable(UserTrackable):
         if is_admin:
             return True
         else:
-            #TODO: This isn't checking for UDFs... should it?
             writeable_perms = self._get_writeable_perms_set(user)
             return writeable_perms >= set(self.tracked_fields)
 

--- a/opentreemap/treemap/audit.py
+++ b/opentreemap/treemap/audit.py
@@ -701,7 +701,7 @@ class Authorizable(UserTrackable):
 
         self._has_been_masked = False
 
-    def _get_perms_set(self, user, direct_only=False):
+    def _get_writeable_perms_set(self, user, direct_only=False):
 
         if not self.instance:
             raise AuthorizeException(trans(
@@ -744,7 +744,8 @@ class Authorizable(UserTrackable):
             return True
         else:
             #TODO: This isn't checking for UDFs... should it?
-            return self._get_perms_set(user) >= set(self.tracked_fields)
+            writeable_perms = self._get_writeable_perms_set(user)
+            return writeable_perms >= set(self.tracked_fields)
 
     def user_can_create(self, user, direct_only=False):
         """
@@ -757,7 +758,7 @@ class Authorizable(UserTrackable):
         """
         can_create = True
 
-        perm_set = self._get_perms_set(user, direct_only)
+        perm_set = self._get_writeable_perms_set(user, direct_only)
 
         for field in self._fields_required_for_create():
             if field.name not in perm_set:
@@ -840,7 +841,7 @@ class Authorizable(UserTrackable):
         self._assert_not_masked()
 
         if self.pk is not None:
-            writable_perms = self._get_perms_set(user)
+            writable_perms = self._get_writeable_perms_set(user)
             for field in self._updated_fields():
                 if field not in writable_perms:
                     raise AuthorizeException("Can't edit field %s on %s" %

--- a/opentreemap/treemap/instance.py
+++ b/opentreemap/treemap/instance.py
@@ -261,7 +261,8 @@ class Instance(models.Model):
         fields = {
             'standard': [
                 {'identifier': 'tree.diameter', 'search_type': 'RANGE'},
-                {'identifier': 'tree.date_planted', 'search_type': 'RANGE'}
+                {'identifier': 'tree.date_planted', 'search_type': 'RANGE'},
+                {'identifier': 'mapFeature.updated_at', 'search_type': 'RANGE'}
             ],
             'display': [
                 {'model': 'Tree', 'label': 'Show trees'},

--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -537,7 +537,8 @@ class MapFeature(Convertible, UDFModel, PendingAuditable):
     # Although this can be retrieved with a MAX() query on the audit
     # table, we store a "cached" value here to keep filtering easy and
     # efficient.
-    updated_at = models.DateTimeField(default=timezone.now)
+    updated_at = models.DateTimeField(default=timezone.now,
+                                      help_text=trans("Updated On"))
 
     # Tells the permission system that if any other field is writable,
     # updated_at is also writable


### PR DESCRIPTION
Builds on top of #1969

Showing the "always writeable" `updated_at` field required changing a bit more of the mechanics of `Authorizable`, but nothing too significant.