### PR TITLE
Prevent submitting empty comments.

### DIFF
--- a/opentreemap/otm_comments/js/src/comments.js
+++ b/opentreemap/otm_comments/js/src/comments.js
@@ -45,6 +45,18 @@ module.exports = function(config, commentContainerSelector) {
         $('#id_comment').focus();
     });
 
+    $container.on('change keyup paste', 'textarea', function (e) {
+        var $textarea = $(e.currentTarget),
+            $form = $textarea.closest('form'),
+            $submit = $form.find('input[type="submit"]');
+
+        if ($textarea.val().trim() === "") {
+            $submit.prop('disabled', true);
+        } else {
+            $submit.prop('disabled', false);
+        }
+    });
+
     // The default comment form is not part of the page by default
     addMainForm();
     flagging();

--- a/opentreemap/treemap/templates/treemap/map_feature_detail.html
+++ b/opentreemap/treemap/templates/treemap/map_feature_detail.html
@@ -240,7 +240,7 @@
     <input type="hidden" name="next" value="{{request.get_full_path}}" />
     <input type="hidden" name="markup" value="5">
     <div class="submit">
-      <input type="submit" name="post" class="submit-post btn btn-primary" value="Post" />
+      <input disabled="disabled" type="submit" name="post" class="submit-post btn btn-primary" value="Post" />
     </div>
   </form>
 </script>


### PR DESCRIPTION
Attempting to post an empty comment would lead to incorrect behaviour
like redirecting to an unstyled page.

This commit fixes the issue by disabling the submit button when the
textbox is empty, and enabling when text has been entered.

Fixes #1596