### PR TITLE
Allow map admins to disable exports

### DIFF
--- a/opentreemap/exporter/__init__.py
+++ b/opentreemap/exporter/__init__.py
@@ -1,0 +1,7 @@
+from django.utils.translation import ugettext_lazy as trans
+
+
+EXPORTS_NOT_ENABLED_CONTEXT = {
+    'start_status': 'ERROR',
+    'message': trans('Data exports are not enabled.')
+}

--- a/opentreemap/exporter/decorators.py
+++ b/opentreemap/exporter/decorators.py
@@ -6,6 +6,8 @@ from __future__ import division
 from functools import wraps
 from celery import chain
 
+from exporter import EXPORTS_NOT_ENABLED_CONTEXT
+from exporter.lib import export_enabled_for
 from exporter.models import ExportJob
 from exporter.tasks import simple_async_csv, custom_async_csv
 
@@ -13,6 +15,9 @@ from exporter.tasks import simple_async_csv, custom_async_csv
 def queryset_as_exported_csv(fn):
     @wraps(fn)
     def wrapped_fn(request, instance, *args, **kwargs):
+        if not export_enabled_for(instance, request.user):
+            return EXPORTS_NOT_ENABLED_CONTEXT
+
         qs = fn(request, instance, *args, **kwargs)
 
         job = ExportJob.objects.create(
@@ -34,6 +39,9 @@ def task_output_as_csv(fn):
     @wraps(fn)
     def wrapped_fn(request, instance, *args, **kwargs):
         filename, task, args, fields = fn(request, instance, *args, **kwargs)
+
+        if not export_enabled_for(instance, request.user):
+            return EXPORTS_NOT_ENABLED_CONTEXT
 
         job = ExportJob.objects.create(
             instance=instance,

--- a/opentreemap/exporter/lib.py
+++ b/opentreemap/exporter/lib.py
@@ -1,0 +1,20 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+
+
+def export_enabled_for(instance, user):
+    if instance.feature_enabled('exports'):
+        if instance.non_admins_can_export:
+            return True
+        else:
+            if user.is_authenticated():
+                iuser = user.get_instance_user(instance)
+                return iuser is not None and iuser.admin
+            else:
+                # AnonymousUser can not export
+                # if non_admins_can_export is False
+                return False
+    else:
+        # No one can export if the feature is not enabled
+        return False

--- a/opentreemap/exporter/templatetags/exports.py
+++ b/opentreemap/exporter/templatetags/exports.py
@@ -1,0 +1,10 @@
+from django import template
+
+register = template.Library()
+
+from exporter.lib import export_enabled_for as _export_enabled_for
+
+
+@register.filter
+def export_enabled_for(instance, user):
+    return _export_enabled_for(instance, user)

--- a/opentreemap/exporter/views.py
+++ b/opentreemap/exporter/views.py
@@ -14,6 +14,8 @@ from django_tinsel.decorators import json_api_call
 from treemap.util import get_csv_response, get_json_response
 from treemap.decorators import instance_request, requires_feature
 
+from exporter import EXPORTS_NOT_ENABLED_CONTEXT
+from exporter.lib import export_enabled_for
 from exporter.models import ExportJob
 from exporter.user import write_users
 
@@ -59,6 +61,9 @@ def begin_export_users(request, instance, data_format):
     if not request.user.is_authenticated():
         raise Http404()
 
+    if not export_enabled_for(instance, request.user):
+        return EXPORTS_NOT_ENABLED_CONTEXT
+
     job = ExportJob.objects.create(
         instance=instance,
         user=request.user,
@@ -70,6 +75,9 @@ def begin_export_users(request, instance, data_format):
 
 
 def begin_export(request, instance, model):
+    if not export_enabled_for(instance, request.user):
+        return EXPORTS_NOT_ENABLED_CONTEXT
+
     query = request.GET.get('q', None)
     display_filters = request.GET.get('show', None)
 

--- a/opentreemap/treemap/instance.py
+++ b/opentreemap/treemap/instance.py
@@ -248,6 +248,8 @@ class Instance(models.Model):
     mobile_api_fields = _make_config_property('mobile_api_fields',
                                               DEFAULT_MOBILE_API_FIELDS)
 
+    non_admins_can_export = models.BooleanField(default=True)
+
     @property
     def advanced_search_fields(self):
         # TODO pull from the config once users have a way to set search fields

--- a/opentreemap/treemap/migrations/0097_auto__add_field_instance_non_admins_can_export.py
+++ b/opentreemap/treemap/migrations/0097_auto__add_field_instance_non_admins_can_export.py
@@ -1,0 +1,275 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Instance.non_admins_can_export'
+        db.add_column(u'treemap_instance', 'non_admins_can_export',
+                      self.gf('django.db.models.fields.BooleanField')(default=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Instance.non_admins_can_export'
+        db.delete_column(u'treemap_instance', 'non_admins_can_export')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'treemap.audit': {
+            'Meta': {'object_name': 'Audit'},
+            'action': ('django.db.models.fields.IntegerField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'current_value': ('django.db.models.fields.TextField', [], {'null': 'True', 'db_index': 'True'}),
+            'field': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']", 'null': 'True', 'blank': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'db_index': 'True'}),
+            'model_id': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'db_index': 'True'}),
+            'previous_value': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'ref': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Audit']", 'null': 'True'}),
+            'requires_auth': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.User']"})
+        },
+        u'treemap.benefitcurrencyconversion': {
+            'Meta': {'object_name': 'BenefitCurrencyConversion'},
+            'co2_lb_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'currency_symbol': ('django.db.models.fields.CharField', [], {'max_length': '5'}),
+            'electricity_kwh_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'h20_gal_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'natural_gas_kbtu_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'nox_lb_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'o3_lb_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'pm10_lb_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'sox_lb_to_currency': ('django.db.models.fields.FloatField', [], {}),
+            'voc_lb_to_currency': ('django.db.models.fields.FloatField', [], {})
+        },
+        u'treemap.boundary': {
+            'Meta': {'object_name': 'Boundary'},
+            'category': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'geom': ('django.contrib.gis.db.models.fields.MultiPolygonField', [], {'srid': '3857', 'db_column': "u'the_geom_webmercator'"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'sort_order': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'treemap.favorite': {
+            'Meta': {'unique_together': "((u'user', u'map_feature'),)", 'object_name': 'Favorite'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'map_feature': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.MapFeature']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.User']"})
+        },
+        u'treemap.fieldpermission': {
+            'Meta': {'unique_together': "((u'model_name', u'field_name', u'role', u'instance'),)", 'object_name': 'FieldPermission'},
+            'field_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'model_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'permission_level': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'role': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Role']"})
+        },
+        u'treemap.instance': {
+            'Meta': {'object_name': 'Instance'},
+            'adjuncts_timestamp': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'basemap_data': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'basemap_type': ('django.db.models.fields.CharField', [], {'default': "u'google'", 'max_length': '255'}),
+            'boundaries': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['treemap.Boundary']", 'null': 'True', 'blank': 'True'}),
+            'bounds': ('django.contrib.gis.db.models.fields.MultiPolygonField', [], {'srid': '3857'}),
+            'center_override': ('django.contrib.gis.db.models.fields.PointField', [], {'srid': '3857', 'null': 'True', 'blank': 'True'}),
+            'config': ('treemap.json_field.JSONField', [], {'blank': 'True'}),
+            'default_role': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'default_role'", 'to': u"orm['treemap.Role']"}),
+            'eco_benefits_conversion': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.BenefitCurrencyConversion']", 'null': 'True', 'blank': 'True'}),
+            'geo_rev': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_public': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'itree_region_default': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'}),
+            'logo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'non_admins_can_export': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'url_name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'users': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['treemap.User']", 'null': 'True', 'through': u"orm['treemap.InstanceUser']", 'blank': 'True'})
+        },
+        u'treemap.instanceuser': {
+            'Meta': {'unique_together': "((u'instance', u'user'),)", 'object_name': 'InstanceUser'},
+            'admin': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'reputation': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'role': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Role']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.User']"})
+        },
+        u'treemap.itreecodeoverride': {
+            'Meta': {'unique_together': "((u'instance_species', u'region'),)", 'object_name': 'ITreeCodeOverride'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance_species': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Species']"}),
+            'itree_code': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'region': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.ITreeRegion']"})
+        },
+        u'treemap.itreeregion': {
+            'Meta': {'object_name': 'ITreeRegion'},
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '40'}),
+            'geometry': ('django.contrib.gis.db.models.fields.MultiPolygonField', [], {'srid': '3857'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'treemap.mapfeature': {
+            'Meta': {'object_name': 'MapFeature'},
+            'address_city': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'address_street': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'address_zip': ('django.db.models.fields.CharField', [], {'max_length': '30', 'null': 'True', 'blank': 'True'}),
+            'feature_type': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'geom': ('django.contrib.gis.db.models.fields.PointField', [], {'srid': '3857', 'db_column': "u'the_geom_webmercator'"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'readonly': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'udfs': (u'treemap.udf.UDFField', [], {'db_index': 'True', 'blank': 'True'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'})
+        },
+        u'treemap.mapfeaturephoto': {
+            'Meta': {'object_name': 'MapFeaturePhoto'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'map_feature': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.MapFeature']"}),
+            'thumbnail': ('django.db.models.fields.files.ImageField', [], {'max_length': '100'})
+        },
+        u'treemap.plot': {
+            'Meta': {'object_name': 'Plot', '_ormbases': [u'treemap.MapFeature']},
+            'length': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            u'mapfeature_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['treemap.MapFeature']", 'unique': 'True', 'primary_key': 'True'}),
+            'owner_orig_id': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'width': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'treemap.reputationmetric': {
+            'Meta': {'object_name': 'ReputationMetric'},
+            'action': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'approval_score': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'denial_score': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'direct_write_score': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'model_name': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'treemap.role': {
+            'Meta': {'object_name': 'Role'},
+            'default_permission': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']", 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'rep_thresh': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'treemap.species': {
+            'Meta': {'unique_together': "((u'instance', u'common_name', u'genus', u'species', u'cultivar', u'other_part_of_name'),)", 'object_name': 'Species'},
+            'common_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'cultivar': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'fact_sheet_url': ('django.db.models.fields.URLField', [], {'max_length': '255', 'blank': 'True'}),
+            'fall_conspicuous': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'flower_conspicuous': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'flowering_period': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'fruit_or_nut_period': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'genus': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'has_wildlife_value': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'is_native': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'max_diameter': ('django.db.models.fields.IntegerField', [], {'default': '200'}),
+            'max_height': ('django.db.models.fields.IntegerField', [], {'default': '800'}),
+            'other_part_of_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'otm_code': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'palatable_human': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'plant_guide_url': ('django.db.models.fields.URLField', [], {'max_length': '255', 'blank': 'True'}),
+            'species': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'udfs': (u'treemap.udf.UDFField', [], {'db_index': 'True', 'blank': 'True'})
+        },
+        u'treemap.staticpage': {
+            'Meta': {'object_name': 'StaticPage'},
+            'content': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'treemap.tree': {
+            'Meta': {'object_name': 'Tree'},
+            'canopy_height': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'date_planted': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'date_removed': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'diameter': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'height': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'plot': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Plot']"}),
+            'readonly': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'species': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Species']", 'null': 'True', 'blank': 'True'}),
+            'udfs': (u'treemap.udf.UDFField', [], {'db_index': 'True', 'blank': 'True'})
+        },
+        u'treemap.treephoto': {
+            'Meta': {'object_name': 'TreePhoto', '_ormbases': [u'treemap.MapFeaturePhoto']},
+            u'mapfeaturephoto_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['treemap.MapFeaturePhoto']", 'unique': 'True', 'primary_key': 'True'}),
+            'tree': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Tree']"})
+        },
+        u'treemap.user': {
+            'Meta': {'object_name': 'User'},
+            'allow_email_contact': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'unique': 'True', 'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '30', 'blank': 'True'}),
+            'make_info_public': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'organization': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'photo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'thumbnail': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'treemap.userdefinedcollectionvalue': {
+            'Meta': {'object_name': 'UserDefinedCollectionValue'},
+            'data': (u'django_hstore.fields.DictionaryField', [], {}),
+            'field_definition': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.UserDefinedFieldDefinition']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model_id': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'treemap.userdefinedfielddefinition': {
+            'Meta': {'object_name': 'UserDefinedFieldDefinition'},
+            'datatype': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'iscollection': ('django.db.models.fields.BooleanField', [], {}),
+            'model_type': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        }
+    }
+
+    complete_apps = ['treemap']

--- a/opentreemap/treemap/plugin.py
+++ b/opentreemap/treemap/plugin.py
@@ -13,6 +13,7 @@ from treemap.lib import get_function_by_path
 
 # For use in tests, as basic functions to use in override_settings
 always_false = lambda *args, **kwargs: False
+always_true = lambda *args, **kwargs: True
 
 
 #

--- a/opentreemap/treemap/templates/instance_base.html
+++ b/opentreemap/treemap/templates/instance_base.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 {% load instance_config %}
 {% load form_extras %}
+{% load exports %}
 
 {% block application_css %}
 {% if request.instance.scss_variables %}
@@ -132,7 +133,7 @@
       <div style="display: inline;" id="tree-and-planting-site-counts">
       </div>
       {% block subhead_exports %}
-        {% if request.instance|feature_enabled:'exports' %}
+        {% if request.instance|export_enabled_for:request.user %}
         <a href="javascript:;" class="btn btn-primary btn-xs exportBtn"
            data-export-start-url="{% url 'begin_export' instance_url_name=request.instance.url_name model='tree' %}">
           <i class="icon-export"></i> {% trans "Export Search Results" %}


### PR DESCRIPTION
This commit adds a boolean attribute to the instance model for controlling whether or not non-administrators can download data as CSV.

The flag is checked by a helper method both at the template level, to hide the export button, and at the task level to prevent a template bug or manually crafted request from "leaking" the data when the admins have disallowed it.

The new helper extends the existing check of whether the export feature is enabled at all and, as a result, applies that check in more places than it was being applied previously.

Fixes #1359