### PR TITLE
Add states to import validation

### DIFF
--- a/opentreemap/importer/models/base.py
+++ b/opentreemap/importer/models/base.py
@@ -23,12 +23,14 @@ class GenericImportEvent(models.Model):
 
     PENDING_VERIFICATION = 1
     LOADING = 7
+    PREPARING_VERIFICATION = 9
     VERIFIYING = 2
     FINISHED_VERIFICATION = 3
     CREATING = 4
     FINISHED_CREATING = 5
     FAILED_FILE_VERIFICATION = 6
     CANCELED = 8
+    VERIFICATION_ERROR = 10
 
     # Original Name of the file
     file_name = models.CharField(max_length=255)
@@ -57,11 +59,13 @@ class GenericImportEvent(models.Model):
         summaries = {
             self.PENDING_VERIFICATION: "Not Yet Started",
             self.LOADING: "Loading",
+            self.PREPARING_VERIFICATION: "Preparing Verification",
             self.VERIFIYING: "Verifying",
             self.FINISHED_VERIFICATION: "Verification Complete",
             self.CREATING: "Creating Trees",
             self.FAILED_FILE_VERIFICATION: "Invalid File Structure",
             self.CANCELED: "Canceled",
+            self.VERIFICATION_ERROR: "Verification Error",
         }
         return summaries.get(self.status, "Finished")
 
@@ -81,11 +85,13 @@ class GenericImportEvent(models.Model):
             self.status == self.FINISHED_VERIFICATION or
             self.status == self.FINISHED_CREATING or
             self.status == self.FAILED_FILE_VERIFICATION or
-            self.status == self.CANCELED)
+            self.status == self.CANCELED or
+            self.status == self.VERIFICATION_ERROR)
 
     def can_export(self):
         return (not self.is_running()
-                and self.status != self.FAILED_FILE_VERIFICATION)
+                and self.status != self.FAILED_FILE_VERIFICATION
+                and self.status != self.VERIFICATION_ERROR)
 
     def can_cancel(self):
         return self.status == self.LOADING or self.status == self.VERIFIYING


### PR DESCRIPTION
Import jobs were appearing to be "hung" in the validation step of a tree import for two reasons:

1. The process of chunking up a large import file into tasks takes some time. Rows are not being processed during this setup phase, so the counter appeared to be stuck at zero.

2. An error during the verification setup would cause the task to fail silently without updating the import event status, which remained stuck at "Verifying."

I added two additional import event states to cover these two cases, PREPARING_VERIFICATION and VERIFICATION_ERROR.

Fixes #1979

I tested the PREPARING_VERIFICATION state by importing a 100,000 tree CSV and watching the management page change status

![screen shot 2015-04-08 at 4 45 52 pm](https://cloud.githubusercontent.com/assets/17363/7060539/b09906b8-de37-11e4-858c-6402744dd64a.png)

I tested the VERIFICATION_ERROR status by inserting a ``raise`` into the try block and then importing a tree file.

![screen shot 2015-04-08 at 9 42 47 pm](https://cloud.githubusercontent.com/assets/17363/7060565/4148dc92-de38-11e4-8f02-eff98eee79f0.png)
