### PR TITLE
Prevent inadvertent modification of cached objects by returning copies

### DIFF
--- a/opentreemap/treemap/DotDict.py
+++ b/opentreemap/treemap/DotDict.py
@@ -1,7 +1,12 @@
+from copy import deepcopy
+
+
 class DotDict(dict):
     """
     Dictionary class supporting keys like "a.b.c" for nested dictionaries
-    From http://stackoverflow.com/questions/3797957 (RM added get())
+    From http://stackoverflow.com/questions/3797957
+     - RM added get()
+     - MVM added __deepcopy__()
 
     Supports get() with a dotted key and a default, e.g.
         config.get('fruit.apple.type', 'delicious')
@@ -72,6 +77,9 @@ class DotDict(dict):
 
     def __setstate__(self, d):
         self.__dict__ = d
+
+    def __deepcopy__(self, memo):
+        return DotDict(deepcopy(dict(self), memo))
 
     __setattr__ = __setitem__
     __getattr__ = __getitem__

--- a/opentreemap/treemap/lib/object_caches.py
+++ b/opentreemap/treemap/lib/object_caches.py
@@ -1,4 +1,10 @@
 # -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from copy import deepcopy
+
 from django.conf import settings
 from django.db.models import F
 
@@ -125,13 +131,19 @@ class _InstanceAdjuncts:
         if not self._permissions:
             self._load_permissions()
         perms = self._permissions.get((role_id, model_name))
-        return perms if perms else []
+
+        # We must always deepcopy the cached items before returning them,
+        # to prevent inadvertent modifcations to the cached items
+        return deepcopy(perms) if perms else []
 
     def udf_defs(self, model_name):
         if not self._udf_defs:
             self._load_udf_defs()
         defs = self._udf_defs.get(model_name)
-        return defs if defs else []
+
+        # We must always deepcopy the cached items before returning them,
+        # to prevent inadvertent modifcations to the cached items
+        return deepcopy(defs) if defs else []
 
     def _load_roles(self):
         from treemap.models import InstanceUser


### PR DESCRIPTION
Also adds support for deepcopy to `DotDict`, which should fix issues with
pickling it.

Fixes #1764