### PR TITLE
Fix boundary filter on ecobenefits/counts.

### DIFF
--- a/opentreemap/treemap/search.py
+++ b/opentreemap/treemap/search.py
@@ -281,7 +281,7 @@ def _parse_within_radius_value(predicate_value, field=None):
 
 def _parse_in_boundary(boundary_id, field=None):
     boundary = Boundary.objects.get(pk=boundary_id)
-    return {'__contained': boundary.geom}
+    return {'__within': boundary.geom}
 
 
 def _parse_isnull_hstore(value, field):

--- a/opentreemap/treemap/tests/__init__.py
+++ b/opentreemap/treemap/tests/__init__.py
@@ -70,7 +70,7 @@ def make_simple_polygon(n=1):
 
     p1 will be closer to the origin.
     """
-    return Polygon(((n, n), (n, n + 1), (n + 1, n + 1), (n, n)))
+    return Polygon(((n, n), (n, n + 1), (n + 1, n + 1), (n + 1, n), (n, n)))
 
 
 def _set_permissions(instance, role, permissions):

--- a/opentreemap/treemap/tests/test_search.py
+++ b/opentreemap/treemap/tests/test_search.py
@@ -188,7 +188,7 @@ class FilterParserTests(OTMTestCase):
 
         inparams = search._parse_dict_value({'IN_BOUNDARY': b.pk})
         self.assertEqual(inparams,
-                         {'__contained': b.geom})
+                         {'__within': b.geom})
 
     def test_constraints_in(self):
         inparams = search._parse_dict_value({'IN': [1, 2, 3]})


### PR DESCRIPTION
We were using `contained`, which determines if the geometry is within
the bounding box of a boundary.  The more appropriate filter to use is
`within`, which will only match when the geometry is entirely within
the boundary.

Connects to #2010