### PR TITLE
Update importer to handle CR terminated CSV files

### DIFF
--- a/opentreemap/importer/tasks.py
+++ b/opentreemap/importer/tasks.py
@@ -3,7 +3,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
-import csv
 import json
 
 from celery import task, chord
@@ -16,7 +15,8 @@ from importer.models.base import GenericImportEvent, GenericImportRow
 from importer.models.species import SpeciesImportEvent, SpeciesImportRow
 from importer.models.trees import TreeImportEvent, TreeImportRow
 from importer import errors, fields
-from importer.util import clean_row_data, clean_field_name
+from importer.util import (clean_row_data, clean_field_name,
+                           utf8_file_to_csv_dictreader)
 
 BLOCK_SIZE = 250
 
@@ -24,7 +24,7 @@ BLOCK_SIZE = 250
 def _create_rows_for_event(ie, csv_file):
     # Don't use a transaction for this possibly long-running operation
     # so we can show progress. Caller does manual cleanup if necessary.
-    reader = csv.DictReader(csv_file)
+    reader = utf8_file_to_csv_dictreader(csv_file)
 
     field_names = reader.fieldnames
     ie.field_order = json.dumps(field_names)

--- a/opentreemap/importer/util.py
+++ b/opentreemap/importer/util.py
@@ -3,6 +3,9 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
+import codecs
+import csv
+
 
 def _clean_string(s):
     s = s.strip()
@@ -26,3 +29,19 @@ def clean_row_data(h):
 
 def clean_field_name(name):
     return name.lower().strip()
+
+
+def _as_utf8(f):
+    return codecs.EncodedFile(f, 'utf-8')
+
+
+def _guess_dialect_and_reset_read_pointer(f):
+    dialect = csv.Sniffer().sniff(_as_utf8(f).read(4096))
+    f.seek(0)
+    return dialect
+
+
+def utf8_file_to_csv_dictreader(f):
+    dialect = _guess_dialect_and_reset_read_pointer(f)
+    return csv.DictReader(_as_utf8(f),
+                          dialect=dialect)


### PR DESCRIPTION
Using ``csv.Sniffer`` provides us with alternate line ending detection, and we get things like tab separated file detection and support for free.

Files I used to test the imports:
http://cl.ly/1B3b1I0X2Z11/1998_csv_import_test_files.zip

Connects to #1998
